### PR TITLE
Add link to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
           <a class="brand" href="#">Lotus</a>
           <div class="nav-collapse collapse pull-right">
             <ul class="nav">
+              <li><a href="https://github.com/lotus/lotus/blob/master/README.md" target="_blank">Docs</a></li>
               <li><a data-section="features" href="#">Features</a></li>
               <li><a data-section="frameworks" href="#">Frameworks</a></li>
             </ul>


### PR DESCRIPTION
I visited the site mainly to look for the "getting started" guides and had to look around a bit before realizing that the lotus/lotus README is the best starting point. This will hopefully clear up some of the confusion for others as well.
