### PR TITLE
Revert "Add link to documentation"

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -23,7 +23,6 @@
           <a class="brand" href="#">{{ site.inc.title }}</a>
           <div class="nav-collapse collapse pull-right">
             <ul class="nav">
-              <li><a href="https://github.com/lotus/lotus/blob/master/README.md" target="_blank">Docs</a></li>
               <li><a data-section="features" href="#">Features</a></li>
               <li><a data-section="frameworks" href="#">Frameworks</a></li>
             </ul>


### PR DESCRIPTION
UI framework doesn't allow external links in home navigation.
Reverts lotus/lotus.github.io#5
