### PR TITLE
Expose books again.

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -842,6 +842,8 @@ With our validations in place, we can limit our entity creation and redirection 
 module Web::Controllers::Books
   class Create
     include Web::Action
+    
+    expose :book
 
     params do
       param :book do
@@ -852,8 +854,7 @@ module Web::Controllers::Books
 
     def call(params)
       if params.valid?
-        book = Book.new(params[:book])
-        BookRepository.create(book)
+        @book = BookRepository.create(Book.new(params[:book]))
 
         redirect_to '/books'
       end


### PR DESCRIPTION
In moving to this step, the `expose :books` was lost. This caused tests to fail. I've added `expose :books` back, and updated the `BookRepository.create` call to a similar format to that used earlier.
