### PR TITLE
Fix syntax error in code snipper for custom helpers

### DIFF
--- a/source/guides/helpers/custom-helpers.md
+++ b/source/guides/helpers/custom-helpers.md
@@ -48,9 +48,9 @@ module Web
       # ...
 
       load_paths << [
-        'helpers'
+        'helpers',
         'controllers',
-        'views',
+        'views'
       ]
 
       # ...


### PR DESCRIPTION
I spotted a minor syntax error in code snippet on page about custom helpers. This is a small fix for that.