### PR TITLE
Add container around 'lotus' row

### DIFF
--- a/source/_lotus.erb
+++ b/source/_lotus.erb
@@ -1,5 +1,7 @@
 <div id="lotus" class="text-xs-center">
-  <div class="row">
-    Looking for <strong>Lotus</strong>? We renamed the project and it's now called <strong>Hanami</strong>. Read the <a href="/blog/2016/01/22/lotus-is-now-hanami.html">announcement</a>.
+  <div class="container">
+    <div class="row">
+      Looking for <strong>Lotus</strong>? We renamed the project and it's now called <strong>Hanami</strong>. Read the <a href="/blog/2016/01/22/lotus-is-now-hanami.html">announcement</a>.
+    </div>
   </div>
 </div>


### PR DESCRIPTION
If you go to hananmirb.org right now, the page is slightly too wide. You can scrolls sideways a tiny bit.

This is because of the `lotus` partial, which has a row which has negative margins on left and right of `-10px`.

This PR fixes that by wrapping the `.row` div in a `.container` div.