### PR TITLE
Remove padding-bottom from body on guides pages

### DIFF
--- a/source/stylesheets/guides.css
+++ b/source/stylesheets/guides.css
@@ -221,7 +221,6 @@
 }
 body {
   overflow-x: hidden;
-  padding-bottom: 40px;
 }
 .docs-header {
   padding-top: 60px;


### PR DESCRIPTION
All of the ['guides' pages](http://hanamirb.org/guides/) have a 40px padding at the bottom of the body. We don't want that :)
