### PR TITLE
Fix unclosed code tag

### DIFF
--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -215,7 +215,7 @@ end.load!
 ### Use UUID as primary key instead of integer
 
 When using Postgres, you may use [UUID Type](http://www.postgresql.org/docs/8.3/static/datatype-uuid.html) as primary keys instead if integers.
-First of all, you need to enable <code>uuid-ossp<code> extension:
+First of all, you need to enable <code>uuid-ossp</code> extension:
 
 ```ruby
 # db/migrations/20160125223305_enable_uuid_extensions.rb


### PR DESCRIPTION
Fix unclosed code tag on the model overview page. It would create weird blocks around the code examples as they would be nested under another unclosed tag.

Before:

![image](https://cloud.githubusercontent.com/assets/282402/12702647/d2666240-c82e-11e5-9466-2289f84a6529.png)

After:

![image](https://cloud.githubusercontent.com/assets/282402/12702650/e103a470-c82e-11e5-8a34-bd1a0d475e3d.png)