### PR TITLE
Removes duplicate execution order statement

### DIFF
--- a/source/guides/applications/initializers.md
+++ b/source/guides/applications/initializers.md
@@ -16,8 +16,6 @@ They are run **after** the dependencies, the framework and the application code 
   For a given application named <code>Web</code>, they MUST be placed under <code>apps/web/config/initializers</code>.
 </p>
 
-Their execution order is alphabetical.
-
 <p class="warning">
   Initializers are executed in alphabetical order.
 </p>


### PR DESCRIPTION
This line and the one after say exactly the same thing. I've removed this line because it is slightly less explicit than the alternative.