### PR TITLE
Removed old generator's action parameter

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -671,7 +671,7 @@ We'll speed things up a little, so we can quickly get to the good parts.
 First, create a new action for our "New Book" page:
 
 ```
-% hanami generate action web books#new --url=/books/new
+% hanami generate action web books#new
 ```
 
 This adds a new route to our app:


### PR DESCRIPTION
In the past, it used to require the `--url=/path/to/action` parameter, but it doesn't modify anything anymore.