### PR TITLE
link to Atom feed generated by Middleman

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -6,7 +6,7 @@
     <meta name="description" content="Hanami - The web, with simplicity" />
     <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
     <meta name="author" content="Luca Guidi">
-    <link href="http://feeds.feedburner.com/hanamirb" rel="alternate" title="Hanami" type="application/atom+xml" />
+    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
 
     <title>Hanami | <%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
 

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -6,7 +6,7 @@
     <meta name="description" content="Hanami - The web, with simplicity" />
     <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
     <meta name="author" content="Luca Guidi">
-    <link href="http://feeds.feedburner.com/hanamirb" rel="alternate" title="Hanami" type="application/atom+xml" />
+    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
 
     <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
 

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -6,7 +6,7 @@
     <meta name="description" content="Hanami - The web, with simplicity" />
     <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
     <meta name="author" content="Luca Guidi">
-    <link href="http://feeds.feedburner.com/hanamirb" rel="alternate" title="Hanami" type="application/atom+xml" />
+    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
 
     <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -6,7 +6,7 @@
     <meta name="description" content="Hanami - The web, with simplicity" />
     <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
     <meta name="author" content="Luca Guidi">
-    <link href="http://feeds.feedburner.com/hanamirb" rel="alternate" title="Hanami" type="application/atom+xml" />
+    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
 
     <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
 


### PR DESCRIPTION
As a fix to #149 I suggest replacing the dead Feedburner links by link to the Atom feed generated by Middleman.