### PR TITLE
improve pgsql syntax in example

### DIFF
--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -221,7 +221,7 @@ First of all, you need to enable <code>uuid-ossp</code> extension:
 # db/migrations/20160125223305_enable_uuid_extensions.rb
 Hanami::Model.migration do
   change do
-    run 'CREATE EXTENSION "uuid-ossp"'
+    run 'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
   end
 end
 ```


### PR DESCRIPTION
I added 'IF NOT EXISTS' to the 'CREATE EXTENSION' line as that migration will fail if the extension is already created unless 'IF NOT EXISTS' is there as well.  It fails with an error as such:

```
/path/to/gem/lib/sequel/adapters/postgres.rb:186:in `async_exec': PG::DuplicateObject: ERROR:  extension "uuid-ossp" already exists (Sequel::DatabaseError)
```