### PR TITLE
Fix require on custom coercions example

### DIFF
--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -178,6 +178,7 @@ The solution to this problem is to define a custom coercer.
 ```ruby
 # lib/ext/pg_array.rb
 require 'hanami/model/coercer'
+require 'sequel'
 require 'sequel/extensions/pg_array'
 
 class PGArray < Hanami::Model::Coercer


### PR DESCRIPTION
Using:

```ruby
require 'hanami/model/coercer'
require 'sequel/extensions/pg_array'
```

Raise exception:
```
`<top (required)>': uninitialized constant Sequel (NameError)
	from /Users/vyper/Documents/projects/guru-pr/c4p/lib/ext/pg_array.rb:2:in `require'
	from /Users/vyper/Documents/projects/guru-pr/c4p/lib/ext/pg_array.rb:2:in `<top (required)>'
[...]
```

To solve I used:
```ruby
require 'hanami/model/coercer'
require 'sequel'
require 'sequel/extensions/pg_array'
```