### PR TITLE
Fix note about ZSH

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -286,7 +286,7 @@ It gives us an empty action, view and template; it also adds a default route to 
 get '/books', to: 'books#index'
 ```
 
-If you're using ZSH, you may get `zsh: no matches found: books#new`. In that case, you can use:
+If you're using ZSH, you may get `zsh: no matches found: books#index`. In that case, you can use:
 ```
 % hanami generate action web books/index
 ```


### PR DESCRIPTION
I think this is what we want.

I use `zsh` (5.0.6) and I don't have this problem. Is this note necessary? Has anyone else run into this? This note was added in #94.