### PR TITLE
Fix order of routes, add column headers & add home name

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -1047,7 +1047,8 @@ use the special command-line task `routes` to inspect the end result:
 
 ```
 % hanami routes
-          GET, HEAD  /                Web::Controllers::Home::Index
+     Name Method     Path             Action
+
     books GET, HEAD  /books           Web::Controllers::Books::Index
  new_book GET, HEAD  /books/new       Web::Controllers::Books::New
     books POST       /books           Web::Controllers::Books::Create
@@ -1055,6 +1056,7 @@ use the special command-line task `routes` to inspect the end result:
 edit_book GET, HEAD  /books/:id/edit  Web::Controllers::Books::Edit
      book PATCH      /books/:id       Web::Controllers::Books::Update
      book DELETE     /books/:id       Web::Controllers::Books::Destroy
+     home GET, HEAD  /                Web::Controllers::Home::Index
 ```
 
 The output for `hanami routes` shows you the name of the defined helper method (you can suffix this name with `_path` or `_url` and call it on the `routes` helper), the allowed HTTP method, the path and finally the controller action that will be used to handle the request.


### PR DESCRIPTION
I noticed the output of `hanami routes` in the Getting Started guide wasn't accurate:
- The `'/'` route didn't have the `home` name
- The columns didn't have headers 
- The ordering was wrong (the `home` route was first, it should be at the bottom)

This PR fixes all those. 

Note: I removed a lot of the whitespace from the output of `hanami routes`. Here's what it actually looks like:
```
                Name Method     Path                           Action

               books GET, HEAD  /books                         Web::Controllers::Books::Index
            new_book GET, HEAD  /books/new                     Web::Controllers::Books::New
               books POST       /books                         Web::Controllers::Books::Create
                book GET, HEAD  /books/:id                     Web::Controllers::Books::Show
           edit_book GET, HEAD  /books/:id/edit                Web::Controllers::Books::Edit
                book PATCH      /books/:id                     Web::Controllers::Books::Update
                book DELETE     /books/:id                     Web::Controllers::Books::Destroy
                home GET, HEAD  /                              Web::Controllers::Home::Index

```