### PR TITLE
Move shared head tags in partial and default zoom for tablets and phones

### DIFF
--- a/source/_head.erb
+++ b/source/_head.erb
@@ -3,6 +3,7 @@
 <meta name="description" content="Hanami - The web, with simplicity" />
 <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
 <meta name="author" content="Luca Guidi">
+<meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
 
 <title>Hanami | <%= current_page.data.title || "Hanami | The web, with simplicity." %></title>

--- a/source/_head.erb
+++ b/source/_head.erb
@@ -1,0 +1,12 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="description" content="Hanami - The web, with simplicity" />
+<meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
+<meta name="author" content="Luca Guidi">
+<link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
+
+<title>Hanami | <%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
+
+<link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,700" rel="stylesheet">
+<%= stylesheet_link_tag 'toolkit-minimal' %>
+<%= stylesheet_link_tag 'application-minimal' %>

--- a/source/blog.html.erb
+++ b/source/blog.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Blog
+title: Blog
 ---
 <div class="container container-blog">
   <div class="block block-inverse text-center">

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Community
+title: Community
 ---
 
 <h1 class="page-header">Hanami Community</h1>

--- a/source/guides/actions/basic-usage.md
+++ b/source/guides/actions/basic-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Actions Basic Usage
+title: Guides - Actions Basic Usage
 ---
 
 # Basic Usage

--- a/source/guides/actions/control-flow.md
+++ b/source/guides/actions/control-flow.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Control Flow
+title: Guides - Action Control Flow
 ---
 
 # Control Flow

--- a/source/guides/actions/cookies.md
+++ b/source/guides/actions/cookies.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Cookies
+title: Guides - Action Cookies
 ---
 
 # Cookies

--- a/source/guides/actions/exception-handling.md
+++ b/source/guides/actions/exception-handling.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Exception Handling
+title: Guides - Action Exception Handling
 ---
 
 # Exception Handling

--- a/source/guides/actions/exposures.md
+++ b/source/guides/actions/exposures.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami - Guides - Action Exposures
+title: Guides - Action Exposures
 ---
 
 # Exposures

--- a/source/guides/actions/http-caching.md
+++ b/source/guides/actions/http-caching.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action HTTP Caching
+title: Guides - Action HTTP Caching
 ---
 
 # HTTP Caching

--- a/source/guides/actions/mime-types.md
+++ b/source/guides/actions/mime-types.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action MIME Types
+title: Guides - Action MIME Types
 ---
 
 # MIME Types

--- a/source/guides/actions/overview.md
+++ b/source/guides/actions/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Actions Overview
+title: Guides - Actions Overview
 ---
 
 # Overview

--- a/source/guides/actions/parameters.md
+++ b/source/guides/actions/parameters.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Parameters
+title: Guides - Action Parameters
 ---
 
 # Parameters

--- a/source/guides/actions/rack-integration.md
+++ b/source/guides/actions/rack-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Request & Response
+title: Guides - Request & Response
 ---
 
 # Rack Integration

--- a/source/guides/actions/request-and-response.md
+++ b/source/guides/actions/request-and-response.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Request & Response
+title: Guides - Request & Response
 ---
 
 # Request

--- a/source/guides/actions/sessions.md
+++ b/source/guides/actions/sessions.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Sessions
+title: Guides - Action Sessions
 ---
 
 # Sessions

--- a/source/guides/actions/share-code.md
+++ b/source/guides/actions/share-code.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Share Code
+title: Guides - Action Share Code
 ---
 
 # Share Code

--- a/source/guides/actions/testing.md
+++ b/source/guides/actions/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Action Testing
+title: Guides - Action Testing
 ---
 
 # Testing

--- a/source/guides/applications/initializers.md
+++ b/source/guides/applications/initializers.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Applications Initializers
+title: Guides - Applications Initializers
 ---
 
 # Initializers

--- a/source/guides/applications/rake.md
+++ b/source/guides/applications/rake.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Applications Rake Tasks
+title: Guides - Applications Rake Tasks
 ---
 
 # Rake Tasks

--- a/source/guides/architectures/application.md
+++ b/source/guides/architectures/application.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Architectures: Application"
+title: "Guides - Architectures: Application"
 ---
 
 # Architectures

--- a/source/guides/architectures/container.md
+++ b/source/guides/architectures/container.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Architectures: Container"
+title: "Guides - Architectures: Container"
 ---
 
 # Architectures

--- a/source/guides/architectures/overview.md
+++ b/source/guides/architectures/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Architectures
+title: Guides - Architectures
 ---
 
 # Architectures

--- a/source/guides/assets/compressors.md
+++ b/source/guides/assets/compressors.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Assets Compressors
+title: Guides - Assets Compressors
 ---
 
 # Assets

--- a/source/guides/assets/content-delivery-network.md
+++ b/source/guides/assets/content-delivery-network.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Assets Content Delivery Network (CDN)
+title: Guides - Assets Content Delivery Network (CDN)
 ---
 
 # Assets

--- a/source/guides/assets/overview.md
+++ b/source/guides/assets/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Assets Overview
+title: Guides - Assets Overview
 ---
 
 # Assets

--- a/source/guides/assets/preprocessors.md
+++ b/source/guides/assets/preprocessors.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Assets Preprocessors
+title: Guides - Assets Preprocessors
 ---
 
 # Assets

--- a/source/guides/command-line/applications.md
+++ b/source/guides/command-line/applications.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Applications"
+title: "Guides - Command Line: Applications"
 ---
 
 # Command Line

--- a/source/guides/command-line/assets.md
+++ b/source/guides/command-line/assets.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Assets"
+title: "Guides - Command Line: Assets"
 ---
 
 # Command Line

--- a/source/guides/command-line/database.md
+++ b/source/guides/command-line/database.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Database"
+title: "Guides - Command Line: Database"
 ---
 
 # Command Line

--- a/source/guides/command-line/destroy.md
+++ b/source/guides/command-line/destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Destroy"
+title: "Guides - Command Line: Destroy"
 ---
 
 # Command Line

--- a/source/guides/command-line/generators.md
+++ b/source/guides/command-line/generators.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Generators"
+title: "Guides - Command Line: Generators"
 ---
 
 # Command Line

--- a/source/guides/command-line/routes.md
+++ b/source/guides/command-line/routes.md
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Routes"
+title: "Guides - Command Line: Routes"
 ---
 
 # Command Line

--- a/source/guides/command-line/version.md.erb
+++ b/source/guides/command-line/version.md.erb
@@ -1,5 +1,5 @@
 ---
-title: "Hanami | Guides - Command Line: Version"
+title: "Guides - Command Line: Version"
 ---
 
 # Command Line

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Getting Started
+title: Guides - Getting Started
 ---
 
 # Getting Started

--- a/source/guides/helpers/assets.md
+++ b/source/guides/helpers/assets.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami - Guides - Assets Helpers
+title: Guides - Assets Helpers
 ---
 
 ## Assets Helpers

--- a/source/guides/helpers/custom-helpers.md
+++ b/source/guides/helpers/custom-helpers.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Custom Helpers
+title: Guides - Custom Helpers
 ---
 
 ## Custom Helpers

--- a/source/guides/helpers/escape.md
+++ b/source/guides/helpers/escape.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Markup Escape Helpers
+title: Guides - Markup Escape Helpers
 ---
 
 ## Markup Escape Helpers

--- a/source/guides/helpers/forms.md
+++ b/source/guides/helpers/forms.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Form Helpers
+title: Guides - Form Helpers
 ---
 
 ## Form Helpers

--- a/source/guides/helpers/html5.md
+++ b/source/guides/helpers/html5.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - HTML5 Helpers
+title: Guides - HTML5 Helpers
 ---
 
 ## HTML5 Helpers

--- a/source/guides/helpers/links.md
+++ b/source/guides/helpers/links.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Link Helpers
+title: Guides - Link Helpers
 ---
 
 ## Link Helpers

--- a/source/guides/helpers/numbers.md
+++ b/source/guides/helpers/numbers.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Number Helpers
+title: Guides - Number Helpers
 ---
 
 ## Number Helpers

--- a/source/guides/helpers/overview.md
+++ b/source/guides/helpers/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Helpers Overview
+title: Guides - Helpers Overview
 ---
 
 # Overview

--- a/source/guides/helpers/routing.md
+++ b/source/guides/helpers/routing.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Routing Helpers
+title: Guides - Routing Helpers
 ---
 
 ## Routing Helpers

--- a/source/guides/index.md
+++ b/source/guides/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides
+title: Guides
 ---
 
 # Introduction

--- a/source/guides/mailers/basic-usage.md
+++ b/source/guides/mailers/basic-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Mailers Basic Usage
+title: Guides - Mailers Basic Usage
 ---
 
 # Basic Usage

--- a/source/guides/mailers/delivery.md
+++ b/source/guides/mailers/delivery.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Mailers Delivery
+title: Guides - Mailers Delivery
 ---
 
 # Delivery

--- a/source/guides/mailers/overview.md
+++ b/source/guides/mailers/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Mailers Overview
+title: Guides - Mailers Overview
 ---
 
 # Overview

--- a/source/guides/mailers/share-code.md
+++ b/source/guides/mailers/share-code.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Mailes Share Code
+title: Guides - Mailes Share Code
 ---
 
 # Share Code

--- a/source/guides/mailers/templates.md
+++ b/source/guides/mailers/templates.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - View Templates
+title: Guides - View Templates
 ---
 
 # Templates

--- a/source/guides/mailers/testing.md
+++ b/source/guides/mailers/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Mailers Testing
+title: Guides - Mailers Testing
 ---
 
 # Testing

--- a/source/guides/migrations/alter-table.md
+++ b/source/guides/migrations/alter-table.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Migrations Alter Tables
+title: Guides - Migrations Alter Tables
 ---
 
 # Migrations

--- a/source/guides/migrations/create-table.md
+++ b/source/guides/migrations/create-table.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Migrations Create Tables
+title: Guides - Migrations Create Tables
 ---
 
 # Migrations

--- a/source/guides/migrations/overview.md
+++ b/source/guides/migrations/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Migrations
+title: Guides - Migrations
 ---
 
 # Migrations

--- a/source/guides/models/entities.md
+++ b/source/guides/models/entities.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Entities
+title: Guides - Entities
 ---
 
 # Entities

--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Models Overview
+title: Guides - Models Overview
 ---
 
 # Models

--- a/source/guides/models/repositories.md
+++ b/source/guides/models/repositories.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Repositories
+title: Guides - Repositories
 ---
 
 # Repositories

--- a/source/guides/routing/basic-usage.md
+++ b/source/guides/routing/basic-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Basic Usage
+title: Guides - Basic Usage
 ---
 
 # Basic Usage

--- a/source/guides/routing/overview.md
+++ b/source/guides/routing/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Routing Overview
+title: Guides - Routing Overview
 ---
 
 # Overview

--- a/source/guides/routing/restful-resources.md
+++ b/source/guides/routing/restful-resources.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - RESTful Resource(s)
+title: Guides - RESTful Resource(s)
 ---
 
 # REST

--- a/source/guides/upgrade-notes/v060.md
+++ b/source/guides/upgrade-notes/v060.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Upgrade Notes for v0.6.0
+title: Guides - Upgrade Notes for v0.6.0
 ---
 
 ## Upgrade Notes for v0.6.0

--- a/source/guides/upgrade-notes/v070.md
+++ b/source/guides/upgrade-notes/v070.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Upgrade Notes for v0.7.0
+title: Guides - Upgrade Notes for v0.7.0
 ---
 
 ## Upgrade Notes for v0.7.0

--- a/source/guides/views/basic-usage.md
+++ b/source/guides/views/basic-usage.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Views Basic Usage
+title: Guides - Views Basic Usage
 ---
 
 # Basic Usage

--- a/source/guides/views/custom-error-pages.md
+++ b/source/guides/views/custom-error-pages.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Custom Error Pages
+title: Guides - Custom Error Pages
 ---
 
 # Custom Error Pages

--- a/source/guides/views/layouts.md
+++ b/source/guides/views/layouts.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - View Layouts
+title: Guides - View Layouts
 ---
 
 # Layouts

--- a/source/guides/views/mime-types.md
+++ b/source/guides/views/mime-types.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - MIME Types
+title: Guides - MIME Types
 ---
 
 # MIME Types

--- a/source/guides/views/overview.md
+++ b/source/guides/views/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - Views Overview
+title: Guides - Views Overview
 ---
 
 # Overview

--- a/source/guides/views/share-code.md
+++ b/source/guides/views/share-code.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - View Share Code
+title: Guides - View Share Code
 ---
 
 # Share Code

--- a/source/guides/views/templates.md
+++ b/source/guides/views/templates.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - View Templates
+title: Guides - View Templates
 ---
 
 # Templates

--- a/source/guides/views/testing.md
+++ b/source/guides/views/testing.md
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Guides - View Testing
+title: Guides - View Testing
 ---
 
 # View Testing

--- a/source/hackday.html.erb
+++ b/source/hackday.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Hack Day
+title: Hack Day
 ---
 <h1 class="page-header">Hanami Hack Day</h1>
 <p class="lead">Did you always wanted to play with Hanami but you keep saying: "I never find the time"?</p>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,3 +1,3 @@
 ---
-title: Hanami | The web, with simplicity.
+title: The web, with simplicity.
 ---

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -1,19 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="Hanami - The web, with simplicity" />
-    <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
-    <meta name="author" content="Luca Guidi">
-    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
-
-    <title>Hanami | <%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
-
-    <link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,700" rel="stylesheet">
-    <%= stylesheet_link_tag 'toolkit-minimal' %>
-    <%= stylesheet_link_tag 'application-minimal' %>
-
+    <%= partial 'head' %>
     <meta property="og:site_name"   content="Hanami"/>
     <meta property="og:title"       content="<%= article_title(current_page) %>">
     <meta property="og:url"         content="<%= absolute_url(current_page) %>">

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -1,18 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="Hanami - The web, with simplicity" />
-    <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
-    <meta name="author" content="Luca Guidi">
-    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
-
-    <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
-
-    <link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,700" rel="stylesheet">
-    <%= stylesheet_link_tag 'toolkit-minimal' %>
-    <%= stylesheet_link_tag 'application-minimal' %>
+    <%= partial 'head' %>
     <%= stylesheet_link_tag 'guides' %>
   </head>
 

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -1,18 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="Hanami - The web, with simplicity" />
-    <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
-    <meta name="author" content="Luca Guidi">
-    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
-
-    <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
-
-    <link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,700" rel="stylesheet">
-    <%= stylesheet_link_tag 'toolkit-minimal' %>
-    <%= stylesheet_link_tag 'application-minimal' %>
+    <%= partial 'head' %>
   </head>
   <body>
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,18 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="Hanami - The web, with simplicity" />
-    <meta name="keywords" content="hanami,hanamirb,lotus,lotusrb,web,framework,ruby,open source,oss,os,software,free,free software,architecture,fast,lightweight,testing,tdd,bdd,test driven development,behaviour driven development,full stack,mvc,model view object,pattern,patterns,design patterns,oop,object oriented programming,testability,http,https,routing,router,http router,restful,resource,resources,convention,controller,models,repository,query,sql,interactors,two-step view,view,template,presenters,render,rendering,helpers,erb,haml,tilt,json,xml,yaml,yml,framwork,framewrok,riby,free sowftare"/>
-    <meta name="author" content="Luca Guidi">
-    <link href="/atom.xml" rel="alternate" title="Hanami" type="application/atom+xml" />
-
-    <title><%= current_page.data.title || "Hanami | The web, with simplicity." %></title>
-
-    <link href="http://fonts.googleapis.com/css?family=Roboto:100,300,400,700" rel="stylesheet">
-    <%= stylesheet_link_tag 'toolkit-minimal' %>
-    <%= stylesheet_link_tag 'application-minimal' %>
+    <%= partial 'head' %>
   </head>
 
   <body>

--- a/source/mailing-list.html.erb
+++ b/source/mailing-list.html.erb
@@ -1,5 +1,5 @@
 ---
-title: Hanami | Mailing List
+title: Mailing List
 ---
 
 <%= partial 'mailing_list' %>


### PR DESCRIPTION
Hello!

In this PR I made two things:

### Default zoom
I was reading this docs yesterday on iPad and I always had to zoom in. In this PR I've added default zoom, that make displaying better on phones and tablets:

How it was on iPhone:
![](http://g.recordit.co/cxwFJG6KoK.gif)

Now on iPhone:
![](http://g.recordit.co/T9iwhmZlTM.gif)

How it was on iPad:
![](http://g.recordit.co/2qfeHASilg.gif)

Now on iPad:
(no more empty white areas on sides)
![](http://g.recordit.co/A7JlnPbkxb.gif)


### Move shared head tags to partial
2) I wanted to add one meta tag in `<head>`, but there were few layouts with almost equal tags inside `<head>`, so I moved everything in one partial and added this meta tag there. 

Feel free to merge it, if you like it. Btw, let me know if I can help with any small frontend stuff for hanami!