### PR TITLE
Remove app prefix for DATABASE_URL from guides

### DIFF
--- a/source/guides/applications/rake.md
+++ b/source/guides/applications/rake.md
@@ -61,7 +61,7 @@ Imagine we want to build a Rake task that prints informations about our project:
 
 task print_informations: :preload do
   puts ENV['HANAMI_ENV']             # => "development"
-  puts ENV['BOOKSHELF_DATABASE_URL'] # => "postgres://localhost/bookshelf_development"
+  puts ENV['DATABASE_URL'] # => "postgres://localhost/bookshelf_development"
   puts defined?(User)                # => nil
 end
 ```

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -422,7 +422,7 @@ For example, review `.env.development`:
 
 ```
 # Define ENV variables for development environment
-BOOKSHELF_DATABASE_URL="postgres://localhost/bookshelf_development"
+DATABASE_URL="postgres://localhost/bookshelf_development"
 WEB_SESSIONS_SECRET="21aec7f7371228dd0d4da6a620a1a6b22889edcf0d4fb1c11b8080cd87146eda"
 ```
 
@@ -430,10 +430,10 @@ We can edit the database URL and add the database user and password if needed:
 
 ```
 # It follows the format below:
-BOOKSHELF_DATABASE_URL="[ADAPTER]://[DATABASE_USER]:[DATABASE_USER_PASSWORD]@[HOST]:[PORT]/[DATABASE_NAME]"
+DATABASE_URL="[ADAPTER]://[DATABASE_USER]:[DATABASE_USER_PASSWORD]@[HOST]:[PORT]/[DATABASE_NAME]"
 
 # Example:
-BOOKSHELF_DATABASE_URL="postgres://user:password@localhost:5432/bookshelf_development"
+DATABASE_URL="postgres://user:password@localhost:5432/bookshelf_development"
 ```
 The placeholders **_user_** and **_password_** should be replaced with the correct credentials.
 

--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -55,7 +55,7 @@ Hanami::Model.configure do
   #    adapter type: :sql, uri: 'postgres://localhost/bookshelf_development'
   #    adapter type: :sql, uri: 'mysql://localhost/bookshelf_development'
   #
-  adapter type: :sql, uri: ENV['BOOKSHELF_DATABASE_URL']
+  adapter type: :sql, uri: ENV['DATABASE_URL']
 
   # ...
 end.load!


### PR DESCRIPTION
This is a PR against the `accouncing-v080` branch. The guides still have references to `BOOKSHELF_DATABASE_URL`. 

This PR fixes the guides to just use `DATABASE_URL` instead.

See: hanami/hanami#498