### PR TITLE
refactor(guides) use data instead of hard coding

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -113,6 +113,10 @@ helpers do
   GUIDES_ROOT     = 'source/guides'.freeze
   GUIDES_EDIT_URL = 'https://github.com/hanami/hanami.github.io/edit/build/'.freeze
 
+  def guide_title(item)
+    item.title || item.path.split('-').map(&:capitalize).join(' ')
+  end
+
   def guides_navigation
     result = ''
 

--- a/data/guides.yml
+++ b/data/guides.yml
@@ -1,0 +1,103 @@
+categories:
+  - path: /
+    title: Introduction
+    pages:
+      - path: getting-started
+  - path: architectures
+    pages:
+      - path: overview
+      - path: container
+      - path: application
+  - path: applications
+    pages:
+      - path: initializers
+      - path: rake
+  - path: routing
+    pages:
+      - path: overview
+      - path: basic-usage
+      - path: restful-resources
+        title: RESTful Resource(s)
+  - path: actions
+    pages:
+      - path: overview
+      - path: basic-usage
+      - path: parameters
+      - path: request-and-response
+        title: Request & Response
+      - path: exposures
+      - path: rack-integration
+      - path: mime-types
+        title: MIME Types
+      - path: cookies
+      - path: sessions
+      - path: exception-handling
+      - path: control-flow
+      - path: http-caching
+        title: HTTP Caching
+      - path: share-code
+      - path: testing
+  - path: views
+    pages:
+      - path: overview
+      - path: basic-usage
+      - path: templates
+      - path: mime-types
+        title: MIME Types
+      - path: layouts
+      - path: custom-error-pages
+      - path: share-code
+      - path: testing
+  - path: models
+    pages:
+      - path: overview
+      - path: entities
+      - path: repositories
+  - path: migrations
+    pages:
+      - path: overview
+      - path: create-table
+      - path: alter-table
+  - path: helpers
+    pages:
+      - path: overview
+      - path: html5
+        title: HTML5
+      - path: forms
+      - path: routing
+      - path: assets
+      - path: links
+      - path: escape
+        title: Markup Escape
+      - path: numbers
+      - path: custom-helpers
+  - path: mailers
+    pages:
+      - path: overview
+      - path: basic-usage
+      - path: templates
+      - path: delivery
+      - path: share-code
+      - path: testing
+  - path: assets
+    pages:
+      - path: overview
+      - path: preprocessors
+      - path: compressors
+      - path: content-delivery-network
+        title: Content Delivery Network (CDN)
+  - path: command-line
+    pages:
+      - path: applications
+      - path: generators
+      - path: destroy
+      - path: database
+      - path: assets
+      - path: routes
+      - path: version
+  - path: upgrade-notes
+    pages:
+      - path: v060
+        title: v0.6.0
+      - path: v070
+        title: v0.7.0

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -46,148 +46,18 @@
         <li></li>
         <li><%= guides_edit_article(current_page.source_file) %></li>
 
-        <li class="toc-group">
-          <span>Introduction</span>
-          <ul>
-            <li><a href="/guides/getting-started">Getting Started</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Architectures</span>
-          <ul>
-            <li><a href="/guides/architectures/overview">Overview</a></li>
-            <li><a href="/guides/architectures/container">Container</a></li>
-            <li><a href="/guides/architectures/application">Application</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Applications</span>
-          <ul>
-            <li><a href="/guides/applications/initializers">Initializers</a></li>
-            <li><a href="/guides/applications/rake">Rake</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Routing</span>
-          <ul>
-            <li><a href="/guides/routing/overview">Overview</a></li>
-            <li><a href="/guides/routing/basic-usage">Basic Usage</a></li>
-            <li><a href="/guides/routing/restful-resources">RESTful Resource(s)</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Actions</span>
-          <ul>
-            <li><a href="/guides/actions/overview">Overview</a></li>
-            <li><a href="/guides/actions/basic-usage">Basic Usage</a></li>
-            <li><a href="/guides/actions/parameters">Parameters</a></li>
-            <li><a href="/guides/actions/request-and-response">Request & Response</a></li>
-            <li><a href="/guides/actions/exposures">Exposures</a></li>
-            <li><a href="/guides/actions/rack-integration">Rack Integration</a></li>
-            <li><a href="/guides/actions/mime-types">MIME Types</a></li>
-            <li><a href="/guides/actions/cookies">Cookies</a></li>
-            <li><a href="/guides/actions/sessions">Sessions</a></li>
-            <li><a href="/guides/actions/exception-handling">Exception Handling</a></li>
-            <li><a href="/guides/actions/control-flow">Control Flow</a></li>
-            <li><a href="/guides/actions/http-caching">HTTP Caching</a></li>
-            <li><a href="/guides/actions/share-code">Share Code</a></li>
-            <li><a href="/guides/actions/testing">Testing</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Views</span>
-          <ul>
-            <li><a href="/guides/views/overview">Overview</a></li>
-            <li><a href="/guides/views/basic-usage">Basic Usage</a></li>
-            <li><a href="/guides/views/templates">Templates</a></li>
-            <li><a href="/guides/views/mime-types">MIME Types</a></li>
-            <li><a href="/guides/views/layouts">Layouts</a></li>
-            <li><a href="/guides/views/custom-error-pages">Custom Error Pages</a></li>
-            <li><a href="/guides/views/share-code">Share Code</a></li>
-            <li><a href="/guides/views/testing">Testing</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Models</span>
-          <ul>
-            <li><a href="/guides/models/overview">Overview</a></li>
-            <li><a href="/guides/models/entities">Entities</a></li>
-            <li><a href="/guides/models/repositories">Repositories</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Migrations</span>
-          <ul>
-            <li><a href="/guides/migrations/overview">Overview</a></li>
-            <li><a href="/guides/migrations/create-table">Create Table</a></li>
-            <li><a href="/guides/migrations/alter-table">Alter Table</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Helpers</span>
-          <ul>
-            <li><a href="/guides/helpers/overview">Overview</a></li>
-            <li><a href="/guides/helpers/html5">HTML5</a></li>
-            <li><a href="/guides/helpers/forms">Forms</a></li>
-            <li><a href="/guides/helpers/routing">Routing</a></li>
-            <li><a href="/guides/helpers/assets">Assets</a></li>
-            <li><a href="/guides/helpers/links">Links</a></li>
-            <li><a href="/guides/helpers/escape">Markup Escape</a></li>
-            <li><a href="/guides/helpers/numbers">Numbers</a></li>
-            <li><a href="/guides/helpers/custom-helpers">Custom Helpers</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Mailers</span>
-          <ul>
-            <li><a href="/guides/mailers/overview">Overview</a></li>
-            <li><a href="/guides/mailers/basic-usage">Basic Usage</a></li>
-            <li><a href="/guides/mailers/templates">Templates</a></li>
-            <li><a href="/guides/mailers/delivery">Delivery</a></li>
-            <li><a href="/guides/mailers/share-code">Share Code</a></li>
-            <li><a href="/guides/mailers/testing">Testing</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Assets</span>
-          <ul>
-            <li><a href="/guides/assets/overview">Overview</a></li>
-            <li><a href="/guides/assets/preprocessors">Preprocessors</a></li>
-            <li><a href="/guides/assets/compressors">Compressors</a></li>
-            <li><a href="/guides/assets/content-delivery-network">Content Delivery Network (CDN)</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Command Line</span>
-          <ul>
-            <li><a href="/guides/command-line/applications">Applications</a></li>
-            <li><a href="/guides/command-line/generators">Generators</a></li>
-            <li><a href="/guides/command-line/destroy">Destroy</a></li>
-            <li><a href="/guides/command-line/database">Database</a></li>
-            <li><a href="/guides/command-line/assets">Assets</a></li>
-            <li><a href="/guides/command-line/routes">Routes</a></li>
-            <li><a href="/guides/command-line/version">Version</a></li>
-          </ul>
-        </li>
-
-        <li class="toc-group">
-          <span>Upgrade Notes</span>
-          <ul>
-            <li><a href="/guides/upgrade-notes/v060">v0.6.0</a></li>
-            <li><a href="/guides/upgrade-notes/v070">v0.7.0</a></li>
-          </ul>
-        </li>
+        <% data.guides.categories.each do |category| %>
+          <li class="toc-group">
+            <span><%= guide_title(category) %></span>
+            <ul>
+              <% category.pages.each do |page| %>
+                <li>
+                  <%= link_to(guide_title(page), File.join('/guides', category.path, page.path)) %>
+                </li>
+              <% end %>
+            </ul>
+          </li>
+        <% end %>
       </ul>
 
       <%= yield %>


### PR DESCRIPTION
### description
Refactor guides toc to use data instead of hard coding all links.

### motivation
While reading a guide, I want to go to "next" (or "prev") page from the bottom of page like this (https://www.playframework.com/documentation/2.4.x/NewApplication), but they are hard coded. To generate the next page link automatically, I started with refactoring them. What do you think about this?

Thanks.