### PR TITLE
Add special page with status of all hanami parts

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -9,6 +9,7 @@
           <li><a href="https://github.com/hanami" target="_blank">GitHub</a></li>
           <li><a href="https://twitter.com/hanamirb" target="_blank">Twitter</a></li>
           <li><a href="https://rubygems.org/gems/hanami" target="_blank">Rubygems</a></li>
+          <li><a href="/status" target="_blank">Gems Status</a></li>
         </ul>
       </div>
       <div class="col-sm-2 m-b">

--- a/source/_navbar.erb
+++ b/source/_navbar.erb
@@ -1,0 +1,37 @@
+<nav class="navbar navbar-default navbar-static-top navbar-padded text-uppercase app-navbar">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed p-x-0" data-toggle="collapse" data-target="#navbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="/">
+        <span>Hanami</span>
+      </a>
+    </div>
+    <div class="navbar-collapse collapse" id="navbar-collapse">
+      <ul class="nav navbar-nav navbar-right">
+        <li>
+          <a href="/guides">Guides</a>
+        </li>
+        <li>
+          <a href="/community">Community</a>
+        </li>
+        <li>
+          <a href="/donate">Donate</a>
+        </li>
+        <li>
+          <a href="/status">Status</a>
+        </li>
+        <li>
+          <a href="https://github.com/hanami" target="_blank">Source Code</a>
+        </li>
+        <li>
+          <a href="/blog">Blog</a>
+        </li>
+      </ul>
+    </div><!--/.nav-collapse -->
+  </div>
+</nav>

--- a/source/_navbar.erb
+++ b/source/_navbar.erb
@@ -23,9 +23,6 @@
           <a href="/donate">Donate</a>
         </li>
         <li>
-          <a href="/status">Status</a>
-        </li>
-        <li>
           <a href="https://github.com/hanami" target="_blank">Source Code</a>
         </li>
         <li>

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -18,40 +18,7 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-default navbar-static-top navbar-padded text-uppercase app-navbar">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed p-x-0" data-toggle="collapse" data-target="#navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">
-            <span>Hanami</span>
-          </a>
-        </div>
-        <div class="navbar-collapse collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-            <li>
-              <a href="/guides">Guides</a>
-            </li>
-            <li>
-              <a href="/community">Community</a>
-            </li>
-            <li>
-              <a href="/donate">Donate</a>
-            </li>
-            <li>
-              <a href="https://github.com/hanami" target="_blank">Source Code</a>
-            </li>
-            <li class="active">
-              <a href="/blog">Blog</a>
-            </li>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
-    </nav>
+    <%= partial 'navbar' %>
 
     <div class="container">
       <div class="block block-inverse text-center">

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -6,40 +6,7 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-default navbar-static-top navbar-padded text-uppercase app-navbar">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed p-x-0" data-toggle="collapse" data-target="#navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">
-            <span>Hanami</span>
-          </a>
-        </div>
-        <div class="navbar-collapse collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-            <li class="active">
-              <a href="/guides">Guides</a>
-            </li>
-            <li>
-              <a href="/community">Community</a>
-            </li>
-            <li>
-              <a href="/donate">Donate</a>
-            </li>
-            <li>
-              <a href="https://github.com/hanami" target="_blank">Source Code</a>
-            </li>
-            <li>
-              <a href="/blog">Blog</a>
-            </li>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
-    </nav>
+    <%= partial 'navbar' %>
 
     <div class="container docs-content">
       <ul id="markdown-toc">

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -30,6 +30,9 @@
               <a href="/donate">Donate</a>
             </li>
             <li>
+              <a href="/status">Status</a>
+            </li>
+            <li>
               <a href="https://github.com/hanami" target="_blank">Source Code</a>
             </li>
             <li>

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -4,44 +4,7 @@
     <%= partial 'head' %>
   </head>
   <body>
-
-    <nav class="navbar navbar-default navbar-static-top navbar-padded text-uppercase app-navbar">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed p-x-0" data-toggle="collapse" data-target="#navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">
-            <span>Hanami</span>
-          </a>
-        </div>
-        <div class="navbar-collapse collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-            <li>
-              <a href="/guides">Guides</a>
-            </li>
-            <li>
-              <a href="/community">Community</a>
-            </li>
-            <li>
-              <a href="/donate">Donate</a>
-            </li>
-            <li>
-              <a href="/status">Status</a>
-            </li>
-            <li>
-              <a href="https://github.com/hanami" target="_blank">Source Code</a>
-            </li>
-            <li>
-              <a href="/blog">Blog</a>
-            </li>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
-    </nav>
+    <%= partial 'navbar' %>
 
     <div class="block app-block-intro">
       <div class="container text-center">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -5,40 +5,7 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-default navbar-static-top navbar-padded text-uppercase app-navbar">
-      <div class="container">
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed p-x-0" data-toggle="collapse" data-target="#navbar-collapse">
-            <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="/">
-            <span>Hanami</span>
-          </a>
-        </div>
-        <div class="navbar-collapse collapse" id="navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-            <li>
-              <a href="/guides">Guides</a>
-            </li>
-            <li>
-              <a href="/community">Community</a>
-            </li>
-            <li>
-              <a href="/donate">Donate</a>
-            </li>
-            <li>
-              <a href="https://github.com/hanami" target="_blank">Source Code</a>
-            </li>
-            <li>
-              <a href="/blog">Blog</a>
-            </li>
-          </ul>
-        </div><!--/.nav-collapse -->
-      </div>
-    </nav>
+    <%= partial 'navbar' %>
 
     <div class="container">
       <%= yield %>

--- a/source/status.html.erb
+++ b/source/status.html.erb
@@ -1,0 +1,197 @@
+---
+title: Status
+---
+
+<p>The hanami ecosystem consists of many different parts.</p>
+
+<p>With so many projects, it can be difficult to keep up on the status
+of each one. Below is a break-down for each part of hanami, the current
+stable released version, and the build status for the master branch.</p>
+
+<table class="status">
+  <tr>
+    <th>Project</th>	
+    <th>Released Version</th>
+    <th>Master Build Status</th>
+  </tr>
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/hanami">
+        Hanami
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami">
+        <img src="https://badge.fury.io/rb/hanami.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/hanami?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/hanami.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/router">
+        Router
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-router">
+        <img src="https://badge.fury.io/rb/hanami-router.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/router?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/router.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/controller">
+        Controller
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-controller">
+        <img src="https://badge.fury.io/rb/hanami-controller.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/controller?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/controller.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/model">
+        Model
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-model">
+        <img src="https://badge.fury.io/rb/hanami-model.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/model?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/model.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/validations">
+        Validations
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-validations">
+        <img src="https://badge.fury.io/rb/hanami-validations.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/validations?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/validations.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/utils">
+        Utils
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-utils">
+        <img src="https://badge.fury.io/rb/hanami-utils.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/utils?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/utils.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/view">
+        View
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-view">
+        <img src="https://badge.fury.io/rb/hanami-view.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/view?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/view.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/helpers">
+        Helpers
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-helpers">
+        <img src="https://badge.fury.io/rb/hanami-helpers.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/helpers?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/helpers.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/mailer">
+        Mailer
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-mailer">
+        <img src="https://badge.fury.io/rb/hanami-mailer.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/mailer?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/mailer.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <a href="http://github.com/hanami/assets">
+        Assets
+      </a>
+    </td>
+    <td>
+      <a href="http://badge.fury.io/rb/hanami-assets">
+        <img src="https://badge.fury.io/rb/hanami-assets.svg">
+      </a>
+    </td>
+    <td>
+      <a href="http://travis-ci.org/hanami/assets?branch=master">
+        <img src="https://secure.travis-ci.org/hanami/assets.svg?branch=master">
+      </a>
+    </td>
+  </tr>
+</table>
+

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -182,3 +182,25 @@ div.supporters {
   color: #fff;
   text-decoration: underline;
 }
+
+table.status {
+  width: 100%;
+}
+
+table.status tr:nth-child(even) {
+background-color: #f2f2f2;
+}
+
+table.status th, td {
+    padding: 10px;
+    text-align: left;
+}
+
+table.status th {
+  height: 50px;
+  font-size: 20px;
+}
+
+table.status td {
+  font-size: 16px;
+}


### PR DESCRIPTION
I found this idea on [ROM site](http://rom-rb.org/status/). Also I'll be very glad to any comments and suggestions 💚 

## Screenshots
### Desktop
![screenshot 2016-05-25 01 59 56](https://cloud.githubusercontent.com/assets/1147484/15522801/f1e35956-2225-11e6-94e0-e44963f07953.jpg)

### Mobile
![screenshot 2016-05-25 02 00 04](https://cloud.githubusercontent.com/assets/1147484/15522805/f65e2f9c-2225-11e6-95bc-4514693091c5.jpg)

/cc @hanami/core-team and @hanami/contributors 