### PR TITLE
Using string instead of symbol to call key

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -791,7 +791,7 @@ describe Web::Controllers::Books::Create do
     action.call(params)
 
     action.book.id.wont_be_nil
-    action.book.title.must_equal params[:book][:title]
+    action.book.title.must_equal params[:book]['title']
   end
 
   it 'redirects the user to the books listing' do


### PR DESCRIPTION
Following the "getting started" guide, [this test](https://github.com/hanami/hanami.github.io/blame/e975e70358a5a7da48387bd8722081d3861a8aa4/source/guides/getting-started.md#L790) failed:
```
  1) Failure:
Web::Controllers::Books::Create#test_0001_creates a new book [/files/alter/workspace/bookshelf/spec/web/controllers/books/create_spec.rb:17]:
Expected: nil
  Actual: "Confident Ruby"
```
And that's because after call `action.call(params)`, the `params` var is changing from this:
```
[1] pry(#<Web::Controllers::Books::Create>)> params
=> {:book=>{:title=>"Confident Ruby", :author=>"Avdi Grimm"}}
```
 into this:
```
[3] pry(#<Web::Controllers::Books::Create>)> params
=> {:book=>{"title"=>"Confident Ruby", "author"=>"Avdi Grimm"},
 "hanami.action"=>
  #<Web::Controllers::Books::Create:0x00000005211b78
   @_body=["Found"],
   @_env={...},
   @_status=302,
   @accept="*/*",
   @book=#<Book:0x005210160 @id=84 @title="Confident Ruby" @author="Avdi Grimm">,
   @exposures=
    {:params=>
      #<Web::Controllers::Books::Create::Params:0x00000005211560
       @attributes=
        #<Hanami::Utils::Attributes:0x00000005211470 @attributes={"book"=>{"title"=>"Confident Ruby", "author"=>"Avdi Grimm"}}>,
       @env={...},
       @errors=#<Hanami::Validations::Errors:0x00000005203a50 @errors={}>,
       @raw=#<Hanami::Utils::Attributes:0x00000005211470 @attributes={"book"=>{"title"=>"Confident Ruby", "author"=>"Avdi Grimm"}}>>,
     :errors=>#<Hanami::Validations::Errors:0x00000005203a50 @errors={}>,
     :format=>:html,
     :book=>#<Book:0x005210160 @id=84 @title="Confident Ruby" @author="Avdi Grimm">},
   @format=:html,
   @headers=
    {"X-Frame-Options"=>"DENY",
     "Content-Security-Policy"=>
      "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; font-src 'self';",
     "Location"=>"/books",
     "Content-Type"=>"text/html; charset=utf-8"},
   @params=
    #<Web::Controllers::Books::Create::Params:0x00000005211560
     @attributes=
      #<Hanami::Utils::Attributes:0x00000005211470 @attributes={"book"=>{"title"=>"Confident Ruby", "author"=>"Avdi Grimm"}}>,
     @env={...},
     @errors=#<Hanami::Validations::Errors:0x00000005203a50 @errors={}>,
     @raw=#<Hanami::Utils::Attributes:0x00000005211470 @attributes={"book"=>{"title"=>"Confident Ruby", "author"=>"Avdi Grimm"}}>>>}
```
