### PR TITLE
Fix failing tests in getting started guide example

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -871,15 +871,14 @@ describe Web::Controllers::Books::Create do
 
     it 're-renders the books#new view' do
       response = action.call(params)
-      response[0].must_equal 200
+      response[0].must_equal 422
     end
 
     it 'sets errors attribute accordingly' do
       response = action.call(params)
-      response[0].must_equal 422
 
-      action.errors[:book][:title].must_equal  ['is missing']
-      action.errors[:book][:author].must_equal ['is missing']
+      action.params.errors[:book][:title].must_equal  ['is missing']
+      action.params.errors[:book][:author].must_equal ['is missing']
     end
   end
 end
@@ -965,7 +964,7 @@ class NewBookParams < Hanami::Action::Params
 end
 
 describe Web::Views::Books::New do
-  let(:params)    { NewBookParams.new({}) }
+  let(:params)    { NewBookParams.new({book: {}}) }
   let(:exposures) { Hash[params: params] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/new.html.erb') }
   let(:view)      { Web::Views::Books::New.new(template, exposures) }
@@ -975,8 +974,8 @@ describe Web::Views::Books::New do
     params.valid? # trigger validations
 
     rendered.must_include('There was a problem with your submission')
-    rendered.must_include('title is missing')
-    rendered.must_include('author is missing')
+    rendered.must_include('Title is missing')
+    rendered.must_include('Author is missing')
   end
 end
 ```


### PR DESCRIPTION
Since this isn't directly testable, here's the bookshelf example with these updates, which passes the tests: https://github.com/bruz/bookshelf-delivery-example/tree/getting-started-guide-v080