### PR TITLE
Fix bold markup in Model Overview guide

### DIFF
--- a/source/guides/models/overview.md
+++ b/source/guides/models/overview.md
@@ -210,7 +210,7 @@ end.load!
 ```
 
 <p class="warning">
-  A custom coercer **MUST** respond to <code>.dump(value)</code> for serialization and to <code>.load(value)</code> for deserialization.
+  A custom coercer <strong>MUST</strong> respond to <code>.dump(value)</code> for serialization and to <code>.load(value)</code> for deserialization.
 </p>
 
 ### Use UUID as primary key instead of integer


### PR DESCRIPTION
Since the text “MUST” is within `<p>` HTML tags, it must be marked up with `<strong>…</strong>` HTML tags instead of `**…**` Markdown syntax.

That section on the live site: http://hanamirb.org/guides/models/overview/#custom-coercions