### PR TITLE
Added Utils Hanami::Interactor explanation with a real-world example. Indented some sloppily-formatted code.

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -100,6 +100,9 @@ categories:
       - path: assets
       - path: routes
       - path: version
+  - path: utilities
+    pages:
+      - path: interactor
   - path: upgrade-notes
     pages:
       - path: v060

--- a/source/guides/utilities/interactor.md
+++ b/source/guides/utilities/interactor.md
@@ -1,0 +1,125 @@
+#### What is an Interactor?
+
+`Interactor` is an extremely powerful module as part of `Hanami::Utils`. Let's look at some basics, a practical example and then see what makes the `Interactor` so useful and powerful.
+
+`Hanami::Interactor` is a take on a Service Object pattern. In short, in will encapsulate functionality for us.
+
+#### Overview
+`Hanami::Interactor` is a "wrapper" for functionality - it provides generic, automatic tools for interacting with it, hence the name.
+
+Because it's just a module, it can be `include`d in a class. It will give you access to the following methods and functionality:
+
+* `Interactor` class will call `self.valid?` after initialization unless `self.valid?` returns `true`. 
+> Note that `self.valid?` must return `true` or `false` - "truthy" or "falsy" returns will result in a failed status!
+2. In order to use the `Interactor`, the host class must have the following methods present: `.initialize()`, `.call()` and an (optional) private method `.valid?()`.
+3. `error()` method is provided to catalogue errors (this does not stop code execution, but results in a failed interaction). Accepts a string.
+4. `error!()` method keeps the first error string provided, fails the interaction and like `error()`, doesn't prevent the code from working.
+6. `fail!()` is like `error!()`, except it halts further code execution.
+
+Last but not least, the result of a `.call()` method is a `Hanami::Interactor::Result` object. You can call `.success?` on it to see the result of the interaction (which will return a `Boolean`) or you can see accumulated errors array by calling `.errors`. 
+
+Lastly, if any session variable has been `expose`d in the class, `Hanami::Interactor::Result` will expose it as well.
+
+#### The Example
+
+Let's say someone is abusing our Bookshelf program by submitting books using automated tools, resulting in thousands of bunk titles. We implement a ReCaptcha class to stop them.
+
+There is a lot to go through, but don't be discouraged as you look, and we'll make sense of it:
+
+```ruby
+require 'hanami/interactor'
+require 'httparty'
+
+class ReCaptcha
+  include Hanami::Interactor
+  expose :remote_ip
+
+  def initialize(**params)
+    @params = params
+  end
+
+  def call
+    error("Fatal: ENV['RECAPTCHA_SECRET'] is not set!") unless ENV['RECAPTCHA_SECRET']
+    error("Fatal: ENV['RECAPTCHA_URL'] is not set!")    unless ENV['RECAPTCHA_URL']
+
+    recaptcha_data  = @params[:recaptcha_token]
+    remote_ip       = @params[:remote_ip]
+    post_body       = build_POST_body
+
+    response = HTTParty.post(URI.parse(ENV['RECAPTCHA_URL']), { body: post_body })
+
+    unless response['success']
+      error('ReCaptcha check returned `false`. This happens if someone tried to submit the form anyway.')
+      error(response['ReCaptchaErrors']) if response['error-codes']
+    end
+  end
+
+  def valid?
+    result = Params.call(@params)
+    result.success?
+  end
+
+  # Dry::Validation.Schema returns and thus defines a 
+  # class inside of ReCaptcha class.
+  # Read more about how this works: https://github.com/dry-rb/dry-validation
+  Params = Dry::Validation.Schema do
+    required(:recaptcha_token) { filled? & type?(String) }
+    required(:remote_ip)       { filled? & type?(String) }
+  end
+
+  private
+  def build_POST_body
+    "secret=#{ENV['RECAPTCHA_SECRET']}&remote_ip=#{@params[:remote_ip]}&response=#{@params[:recaptcha_token]}"
+  end
+end
+```
+
+That's quite a bit of code so let's look at it more closely. 
+
+First, we're using an excellent [HTTParty](https://github.com/jnunemaker/httparty) gem to make POSTing to ReCaptcha a breeze. This gem is not required.
+
+Let's look at what happens when one calls `ReCaptcha.new(recaptcha_token: token, remote_ip: ip).call()`:
+
+Assuming the initial input is correct:
+
+1. The initialization occurs and `@params` variable is created.
+2. Immediately after, `valid?` is executed.
+3. If the fields (as per the `Dry::Validation::Schema`) are _empty_ or are _not of type `String`_, the return value will be `false`. Interaction stops and the result object's `.success?` method returns `false`. In this case, let's assume the result is `true`.
+4. Because `.valid?` returned `true`, `.call()` is executed.
+5. ReCaptcha-specific code is executed. Note that any errors collected here will cause the Interaction to fail and are kept for debugging purposes. `error()` methods are completely optional. (So is `.valid?`, actually)
+6. `.call()` is completed and the resulting `Hanami::Interactor::Result` object responds to `.success?` with `true`.
+
+> Please note that any Exceptions throw inside of `.call()` **will be quietly caught for you**, unless `rescue`d them specifically! This could be useful to add another `error()` or more than likely a `fail!()`.
+
+Finally, let's look at how this interactor is useful inside our `apps/web/controllers/home/submit.rb` action:
+
+```ruby
+module Web::Controllers::Home
+  class Submit
+    include Web::Action
+
+    def call(params)
+      result = ReCaptcha.new(
+        recaptcha_data: params[:'g-recaptcha-response'], 
+        remote_ip: ENV['HTTP_X_FORWARDED_FOR']
+      ).call()
+      if result.success?
+        redirect_to routes.captcha_passed
+      else
+        redirect_to routes.captcha_failed
+      end
+    end
+  end
+end
+```
+
+As you can see, our Controller is nice and clean with all of the logic easily testable in the `Interactor`, which will not break our application because all we can expect from `result` is a `Boolean` value.
+
+The `Interactor` now:
+* Cleans up the Action to a series of yes/no gates making our app less likely to blow up with an uncaught exception.
+* Makes testing easier as each `Interactor` can be tested on its own.
+* Compartmentalizes code so that the code can be re-used later instead of being a part of, and dependent on, a framework.
+* Provides a set of tools to monitor (with error()s) or stop (fail!()) busy logic that has no place in the controller/action.
+
+
+When used properly, the `Interactor` eases the pain of testing, cleans up your controllers, compartmentalizes your code and, in general, keeps with the credo that we should avoid errors earlier - in the params - rather than later, in the business logic. If we do encounter them - we'd rather see which feature failed rather than which controller failed.

--- a/source/guides/utilities/interactor.md
+++ b/source/guides/utilities/interactor.md
@@ -119,7 +119,6 @@ The `Interactor` now:
 * Cleans up the Action to a series of yes/no gates making our app less likely to blow up with an uncaught exception.
 * Makes testing easier as each `Interactor` can be tested on its own.
 * Compartmentalizes code so that the code can be re-used later instead of being a part of, and dependent on, a framework.
-* Provides a set of tools to monitor (with error()s) or stop (fail!()) busy logic that has no place in the controller/action.
-
+* Provides a set of tools to monitor (with `error()`s) or stop (`fail!()`) busy logic that has no place in the controller/action.
 
 When used properly, the `Interactor` eases the pain of testing, cleans up your controllers, compartmentalizes your code and, in general, keeps with the credo that we should avoid errors earlier - in the params - rather than later, in the business logic. If we do encounter them - we'd rather see which feature failed rather than which controller failed.

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -98,42 +98,51 @@
 
                   <div class="tab-content">
                     <div role="tabpanel" class="tab-pane active" id="download">
-                      <pre class="language-ruby plaintext"><code><span class="command">% gem install hanami</span>
-Successfully installed hanami-<%= hanami_version %>
-1 gem installed
-<br>
-<span class="command">% hanami new bookshelf</span>
-18 files successfully created
-                      </code></pre>
+                      <pre class="language-ruby plaintext">
+                        <code>
+                          <span class="command">% gem install hanami</span>
+                          Successfully installed hanami-<%= hanami_version %>
+                          1 gem installed
+                          <br>
+                          <span class="command">% hanami new bookshelf</span>
+                          18 files successfully created
+                        </code>
+                      </pre>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="develop">
-                      <pre class="language-ruby plaintext"><code><span class="command">% cd bookshelf &amp;&amp; bundle</span>
-Bundle complete! 6 Gemfile dependencies, 28 gems now installed.
-<br>
-<span class="command">% git add . &amp;&amp; git commit -m "Initial commit"</span>
-[master (root-commit) ecb3a75] Initial commit
- 37 files changed, 527 insertions(+)
-                      </code></pre>
+                      <pre class="language-ruby plaintext">
+                        <code>
+                          <span class="command">% cd bookshelf &amp;&amp; bundle</span>
+                          Bundle complete! 6 Gemfile dependencies, 28 gems now installed.
+                          <br>
+                          <span class="command">% git add . &amp;&amp; git commit -m "Initial commit"</span>
+                          [master (root-commit) ecb3a75] Initial commit
+                           37 files changed, 527 insertions(+)
+                        </code>
+                      </pre>
                     </div>
                     <div role="tabpanel" class="tab-pane" id="deploy">
-                      <pre class="language-ruby plaintext"><code><span class="command">% heroku apps:create</span>
-Creating cherry-blossom-1234... done, stack is cedar-14
-https://cherry-blossom-1234.herokuapp.com/ | https://git.heroku.com/cherry-blossom-1234.git
-Git remote heroku added
-<br>
-<span class="command">% heroku config:add SERVE_STATIC_ASSETS=true</span>
-Setting SERVE_STATIC_ASSETS and restarting ⬢ cherry-blossom-1234... done, v2
-SERVE_STATIC_ASSETS: true
-<br>
-<span class="command">% git push heroku master</span>
-# ...
-remote: Verifying deploy... done.
-To https://git.heroku.com/cherry-blossom-1234.git
- * [new branch]      master -&gt; master
-<br>
-<span class="command">% heroku open</span>
-Opening cherry-blossom-1234... done
-                      </code></pre>
+                      <pre class="language-ruby plaintext">
+                      <code>
+                        <span class="command">% heroku apps:create</span>
+                          Creating cherry-blossom-1234... done, stack is cedar-14
+                          https://cherry-blossom-1234.herokuapp.com/ | https://git.heroku.com/cherry-blossom-1234.git
+                          Git remote heroku added
+                          <br>
+                          <span class="command">% heroku config:add SERVE_STATIC_ASSETS=true</span>
+                          Setting SERVE_STATIC_ASSETS and restarting ⬢ cherry-blossom-1234... done, v2
+                          SERVE_STATIC_ASSETS: true
+                          <br>
+                          <span class="command">% git push heroku master</span>
+                          # ...
+                          remote: Verifying deploy... done.
+                          To https://git.heroku.com/cherry-blossom-1234.git
+                           * [new branch]      master -&gt; master
+                          <br>
+                          <span class="command">% heroku open</span>
+                          Opening cherry-blossom-1234... done
+                      </code>
+                      </pre>
                     </div>
                   </div>
 


### PR DESCRIPTION
This is in reference to issue #215 .

This commit is useful because it adds documentation to the Guide about the Interactor, as there is no documentation on the Interactor at all besides the Rdoc (it's a little arcane and doesn't explain some critical methods). I've also cleaned up some sloppily pasted code.

The explanation is a bit long because the Interactor is a little bit tricky. 

However, I've cut about 50-75% from my original draft thanks to @cllns advice, let's see if we can make it even more palatable. 