### PR TITLE
Add create database instruction to getting started

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -102,10 +102,21 @@ Here's what we need to know:
 * `public` will contain compiled static assets.
 * `spec` contains our tests.
 
-Go ahead and install our gem dependency with Bundler; then we can launch a development server:
+Install our gem dependencies with Bundler:
 
 ```
 % bundle install
+```
+
+Create the application database:
+
+```
+% bundle exec hanami db create
+```
+
+Now we can launch the development server:
+
+```
 % bundle exec hanami server
 ```
 


### PR DESCRIPTION
When following the guide, I ran into an issue due to the bookshelf_development database not existing.  This change updates the instructions to include the step for creating the database prior to running the server.