### PR TITLE
Update community.html.erb

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -82,7 +82,7 @@ available at <a href="http://contributor-covenant.org/version/1/4/">http://contr
 <hr>
 
 <h2>Support</h2>
-<p>If you need support for Hanami, please don't hesitate to ask, we're really happy to help. We have a <a href="http://chat.hanamirb.org" target="_blank">chat</a>, a <a href="https://discuss.hanamirb.org" target="_blank">forum</a> and a <a href="https://stackoverflow.com/questions/tagged/hanami" target="_blank">StackOverflow tag</a>.</p>
+<p>If you need support for Hanami, please don't hesitate to ask, we're really happy to help. We have a <a href="http://chat.hanamirb.org" target="_blank">chat</a>, a <a href="https://discourse.hanamirb.org" target="_blank">forum</a> and a <a href="https://stackoverflow.com/questions/tagged/hanami" target="_blank">StackOverflow tag</a>.</p>
 
 <hr>
 


### PR DESCRIPTION
The link for the forum in the "Support" section was not working.

The [HTTPS version of the forum](https://discuss.hanamirb.org) link did not redirect to Discourse whereas the [non-HTTPS version](http://discuss.hanamirb.org) did.

Alternative fix is to link directly to https://discourse.hanamirb.org OR to fix it in the DNS settings.