### PR TITLE
Add instructions to setup PostgreSQL

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -60,6 +60,9 @@ categories:
       - path: associations
       - path: use-your-own-orm
         title: Use Your Own ORM
+  - path: database-configuration
+    pages:
+      - path: overview
   - path: migrations
     pages:
       - path: overview

--- a/data/guides.yml
+++ b/data/guides.yml
@@ -52,6 +52,7 @@ categories:
   - path: models
     pages:
       - path: overview
+      - path: database-configuration
       - path: repositories
       - path: entities
       - path: data-types
@@ -60,9 +61,6 @@ categories:
       - path: associations
       - path: use-your-own-orm
         title: Use Your Own ORM
-  - path: database-configuration
-    pages:
-      - path: overview
   - path: migrations
     pages:
       - path: overview

--- a/source/guides/database-configuration/overview.md
+++ b/source/guides/database-configuration/overview.md
@@ -4,7 +4,7 @@ title: Guides - Database Configuration Overview
 
 # Overview
 
-Before starting your server, you need to configure database link in <code>.env*</code> files.
+Before starting your server, you need to configure the database link in <code>.env*</code> files.
 
 Open this file for each environment and update <code>DATABASE_URL</code> for your database.
 
@@ -24,16 +24,17 @@ Setup database variable for the test environment:
 DATABASE_URL="postgres://username:password@localhost/bookshelf_test"
 ```
 
-## Prepare tables in database
+# Setup your database
 
-After your database variables setup is done you need to create a table in your database before you're be able to launch a development server.
+After your database variables setup is done you need to create the database and run the migrations before being able to launch a development server.
+
 In your terminal, enter:
 
 ```
 % bundle exec hanami db prepare
 ```
 
-To create a table in database for the test environment, enter:
+To setup your test environment database, enter:
 
 ```
 % HANAMI_ENV=test bundle exec hanami db prepare

--- a/source/guides/database-configuration/overview.md
+++ b/source/guides/database-configuration/overview.md
@@ -1,0 +1,40 @@
+---
+title: Guides - Database Configuration Overview
+---
+
+# Overview
+
+Before starting your server, you need to configure database link in <code>.env*</code> files.
+
+Open this file for each environment and update <code>DATABASE_URL</code> for your database.
+
+## <a href="http://www.postgresql.org/" target="_blank">PostgreSQL</a>
+
+Setup database variable for the development environment:
+
+```
+# .env.development
+DATABASE_URL="postgres://username:password@localhost/bookshelf_development"
+```
+
+Setup database variable for the test environment:
+
+```
+# .env.test
+DATABASE_URL="postgres://username:password@localhost/bookshelf_test"
+```
+
+## Prepare tables in database
+
+After your database variables setup is done you need to create a table in your database before you're be able to launch a development server.
+In your terminal, enter:
+
+```
+% bundle exec hanami db prepare
+```
+
+To create a table in database for the test environment, enter:
+
+```
+% HANAMI_ENV=test bundle exec hanami db prepare
+```

--- a/source/guides/models/database-configuration.md
+++ b/source/guides/models/database-configuration.md
@@ -1,8 +1,8 @@
 ---
-title: Guides - Database Configuration Overview
+title: Guides - Database Configuration
 ---
 
-# Overview
+# Database Configuration
 
 Before starting your server, you need to configure the database link in <code>.env*</code> files.
 

--- a/source/guides/models/database-configuration.md
+++ b/source/guides/models/database-configuration.md
@@ -14,14 +14,14 @@ Setup database variable for the development environment:
 
 ```
 # .env.development
-DATABASE_URL="postgres://username:password@localhost/bookshelf_development"
+DATABASE_URL="postgresql://username:password@localhost/bookshelf_development"
 ```
 
 Setup database variable for the test environment:
 
 ```
 # .env.test
-DATABASE_URL="postgres://username:password@localhost/bookshelf_test"
+DATABASE_URL="postgresql://username:password@localhost/bookshelf_test"
 ```
 
 # Setup your database


### PR DESCRIPTION
When generated a new Hanami project with PostgreSQL I was a bit confused how to setup a database on my local machine (I was not able to start `hanami server` because of database connection error). It's not well documented yet so I spend some time to find the answer.
I'm not sure where is the best place to show the setup instructions but I hope it will be helpful for new Hanami users.
Particularly closes #229.
Cheers!
![postgresql setup](https://cloud.githubusercontent.com/assets/10253312/21220802/53d9edee-c2c3-11e6-8633-b86b45cb4452.png)