### PR TITLE
Small Typos in Associations Guide

### DIFF
--- a/source/guides/models/associations.md
+++ b/source/guides/models/associations.md
@@ -122,7 +122,7 @@ class AuthorRepository < Hanami::Repository
   end
 
   def find_with_books(id)
-    aggregate(:books).where(author_id: id).as(Author).one
+    aggregate(:books).where(authors__id: id).as(Author).one
   end
 end
 ```

--- a/source/guides/models/associations.md
+++ b/source/guides/models/associations.md
@@ -29,7 +29,7 @@ If we need to create an author, contextually with a few books, we need to explic
 
 The same principle applies to read operations: if we want to eager load an author with the associated books, we need an explicit method to do so.
 
-If we don't explicitely load that books, then the resulting data will be `nil`.
+If we don't explicitly load that books, then the resulting data will be `nil`.
 
 ### No Proxy Loader
 
@@ -122,7 +122,7 @@ class AuthorRepository < Hanami::Repository
   end
 
   def find_with_books(id)
-    aggregate(:books).where(authors__id: id).as(Author).one
+    aggregate(:books).where(author_id: id).as(Author).one
   end
 end
 ```


### PR DESCRIPTION
Small typos I found while reading through the docs for the first time

As I am very new to Hanami, can someone confirm that the `where` clause correction makes sense? Thanks.