### PR TITLE
Replace uses of `Web::Routes` with `Web.routes`

### DIFF
--- a/source/guides/routing/basic-usage.md
+++ b/source/guides/routing/basic-usage.md
@@ -78,29 +78,29 @@ get '/hello',     to: 'greet#index', as: :greeting
 get '/books/:id', to: 'books#show',  as: :book
 ```
 
-When a Hanami application starts, it generates a Ruby module at the runtime under our application namespace: eg. `Web::Routes`.
+When a Hanami application starts, it generates a Ruby module at the runtime under our application namespace: eg. `Web.routes`.
 We can use it to generate a relative or absolute URI for our route.
 
 ```ruby
-Web::Routes.path(:root)     # => "/"
-Web::Routes.url(:root)      # => "http://localhost:2300/"
+Web.routes.path(:root)     # => "/"
+Web.routes.url(:root)      # => "http://localhost:2300/"
 
-Web::Routes.path(:greeting) # => "/hello"
-Web::Routes.url(:greeting)  # => "http://localhost:2300/hello"
+Web.routes.path(:greeting) # => "/hello"
+Web.routes.url(:greeting)  # => "http://localhost:2300/hello"
 ```
 
 When we have one or more variables, they can be specified as a Hash.
 
 ```ruby
-Web::Routes.path(:book, id: 1) # => "/books/1"
-Web::Routes.url(:book, id: 1)  # => "http://localhost:2300/books/1"
+Web.routes.path(:book, id: 1) # => "/books/1"
+Web.routes.url(:book, id: 1)  # => "http://localhost:2300/books/1"
 ```
 
 Absolute URL generation is dependent on `scheme`, `host` and `port` settings in `apps/web/application.rb`.
 
 ### Routing Helpers
 
-Generating routes from `Web::Routes` is helpful, because that module can be accessed from anywhere.
+Generating routes from `Web.routes` is helpful, because that module can be accessed from anywhere.
 However, this syntax is noisy.
 
 Hanami has _routing helpers_ available as `routes` in: **actions**, **views** and **templates**.

--- a/source/guides/routing/testing.md
+++ b/source/guides/routing/testing.md
@@ -9,14 +9,14 @@ Hanami has builtin facilities for routing unit tests.
 ## Path Generation
 
 We can assert the generated routes, to do so, we're gonna create a spec file for the purpose.
-`Web::Routes` is the class that holds all the routes for the application named `Web`.
+`Web.routes` is the class that holds all the routes for the application named `Web`.
 
 It exposes a method to generate a path, which takes the [name of a route](/guides/routing/basic-usage#named-routes) as a symbol.
 Here's how to test it.
 
 ```ruby
 # spec/web/routes_spec.rb
-RSpec.describe Web::Routes do
+RSpec.describe Web.routes do
   it 'generates "/"' do
     actual = described_class.path(:root)
     expect(actual).to eq '/'
@@ -35,7 +35,7 @@ We can also do the opposite: starting from a fake Rack env, we can assert that t
 
 ```ruby
 # spec/web/routes_spec.rb
-RSpec.describe Web::Routes do
+RSpec.describe Web.routes do
 
   # ...
 


### PR DESCRIPTION
It seems support for `Web::Routes` references was dropped (accidentally?) in 0.9.0 or later. This change updates the documentation to provide the style of reference that now works: `Web.routes`.

If this was an intentional change, we should probably also update the [upgrade notes](http://hanamirb.org/guides/upgrade-notes/v090/). I'm happy to include that in this PR if so.