### PR TITLE
Add detailed information on mounting applications

### DIFF
--- a/source/guides/routing/overview.md
+++ b/source/guides/routing/overview.md
@@ -76,7 +76,16 @@ get '/rack-app', to: 'rack_app' # it will map to RackApp.new
 
 ### Mounting Applications
 
-If we want to mount an application, we should use `mount`.
+If we want to mount an application, we should use `mount` within the Hanami environment configuration file. The global configuration file is located at `config/environment.rb`. Place `mount` within the Hanami.configure block.
+
+```ruby
+Hanami.configure do
+  mount Web::Application, at: '/'
+  mount OtherApplication.new, at: '/other'
+
+  ...
+end
+```
 
 #### Mounting To A Path
 


### PR DESCRIPTION
The mounting guide explains how to mount to a path and a subdomain but does not
explain where the mount code should live.  Rails mounts within the route config
but Hanami mounts within the environment config.  The difference is worth
documenting.

Fixes #245