### PR TITLE
Add gitter chat on index page

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -55,3 +55,8 @@
   ga('create', 'UA-47369640-1', 'hanamirb.org');
   ga('send', 'pageview');
 </script>
+
+<script>
+  ((window.gitter = {}).chat = {}).options = { room: 'hanami/chat' };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -230,3 +230,17 @@ table.status th {
 table.status td {
   font-size: 16px;
 }
+
+.gitter-open-chat-button {
+  background-color: #534a7f;
+  border-color: #443d68;
+}
+
+.gitter-open-chat-button:focus, .gitter-open-chat-button:hover {
+  background-color: #48416f;
+  text-decoration: none;
+}
+
+.gitter-chat-embed {
+  z-index: 1000;
+}


### PR DESCRIPTION
Hey, I added [sidecar](https://sidecar.gitter.im) to our index page. I can add this to all pages but I think it will be unnecessary. What do you think?

### How it works
![hanami-sidecar](https://cloud.githubusercontent.com/assets/1147484/22118072/656f2fe4-de87-11e6-8bdd-1b29c4f36340.gif)

/cc @jodosha @cllns @hanami/contributors 