### PR TITLE
'Before to' grammar mistake fix

### DIFF
--- a/source/blog/2015-06-23-announcing-lotus-040.html.markdown
+++ b/source/blog/2015-06-23-announcing-lotus-040.html.markdown
@@ -9,7 +9,7 @@ excerpt: >
   New Core Team member, Rails Girls Summer of Code and Guides!
 ---
 
-Before to dive into the details of this release, we want to say **thank you** to our beloved Community.
+Before diving into the details of this release, we want to say **thank you** to our beloved Community.
 In a year we went from an initial release with few features and people around Lotus, to a technology that is having an impact on the Ruby ecosystem.
 
 Without you this wouldn't be possible.
@@ -196,7 +196,7 @@ We care **a lot** about the stability of our public APIs, because it involves co
 Each breaking change is thoughtfully evaluated and we wait for minor releases like this to make developers aware of them.
 
 Designing a large software like Lotus is hard and **we make mistakes**.
-Before to hit 1.0, we want to be sure that we have fixed them.
+Before hitting 1.0, we want to be sure that we have fixed them.
 
 #### Environment Configurations
 

--- a/source/blog/2016-02-05-announcing-hanami-071.html.markdown
+++ b/source/blog/2016-02-05-announcing-hanami-071.html.markdown
@@ -41,7 +41,7 @@ This is a patch release that addresses some bugs reported after [v0.7.0 release]
 ### hanami-assets [v0.2.1](https://github.com/hanami/assets/blob/master/CHANGELOG.md#v021---2016-02-05)
 
   - Fix recursive Sass imports [[Luca Guidi](https://github.com/jodosha)]
-  - Ensure to truncate assets in `public/` before to precompile/copy them [[Luca Guidi](https://github.com/jodosha)]
+  - Ensure to truncate assets in `public/` before precompiling/copying them [[Luca Guidi](https://github.com/jodosha)]
 
 ## Upgrade Instructions
 

--- a/source/guides/views/mime-types.md
+++ b/source/guides/views/mime-types.md
@@ -4,7 +4,7 @@ title: Guides - MIME Types
 
 # MIME Types
 
-A view can handle several MIME Types. Before to dive into this subject, please consider to read how actions handle [MIME Types](/guides/actions/mime-types).
+A view can handle several MIME Types. Before diving into this subject, please consider to read how actions handle [MIME Types](/guides/actions/mime-types).
 
 It's important to highlight the correlation between the _format_ and template name.
 For a given MIME Type, Rack (and then Hanami) associate a _format_ for it.


### PR DESCRIPTION
This PR fixes a grammar mistake on `source/guides/views/mime-types.md`.

More info about this piece of grammar can be found [here](http://www.anglaide.com/before-to/).

The same mistake happens [here](https://github.com/hanami/hanami.github.io/blob/build/source/blog/2015-06-23-announcing-lotus-040.html.markdown), and [here](https://github.com/hanami/hanami.github.io/blob/build/source/blog/2016-02-05-announcing-hanami-071.html.markdown), however I am not sure if fixing it is necessary as they are previous blog entries. 
I can quickly fix them if necessary.