### PR TITLE
Add instructions about how to setup test database

### DIFF
--- a/source/guides/command-line/database.md
+++ b/source/guides/command-line/database.md
@@ -25,6 +25,12 @@ With `db create` we can create the database for the current environment.
 % bundle exec hanami db create
 ```
 
+To be able to run tests, test database has to be explicitly created
+
+```shell
+% HANAMI_ENV=test bundle exec hanami db create
+```
+
 In order to preserve production data, this command can't be run in the production environment.
 
 ### Drop

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -159,9 +159,11 @@ Note that, although Hanami is ready for a Behavior Driven Development workflow o
 We'll go with [Minitest](https://github.com/seattlerb/minitest) here (which is the default), but we can use [RSpec](http://rspec.info) by creating the project with `--test=rspec` option.
 Hanami will then generate helpers and stub files for it.
 
-Nonetheless we'll have to setup the test database to be able to run the tests.
-First we have to define our database url in `.env.test`.
-Now our database is configured we have to create it and migrate our schema by running
+<p class="notice">
+  Please check .env.test in case you need to tweak the database URL.
+</p>
+
+We have to migrate our schema in the test database by running:
 
 ```shell
 % HANAMI_ENV=test bundle exec db prepare

--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -70,7 +70,7 @@ Then we can use the new `hanami` executable to generate a new project:
 
 <p class="notice">
   By default, the project will be setup to use a SQLite database. For real-world projects, you can specify your engine:
-  <code> 
+  <code>
   % hanami new bookshelf --database=postgres
   </code>
 </p>
@@ -158,6 +158,16 @@ Note that, although Hanami is ready for a Behavior Driven Development workflow o
 
 We'll go with [Minitest](https://github.com/seattlerb/minitest) here (which is the default), but we can use [RSpec](http://rspec.info) by creating the project with `--test=rspec` option.
 Hanami will then generate helpers and stub files for it.
+
+Nonetheless we'll have to setup the test database to be able to run the tests.
+First we have to define our database url in `.env.test`.
+Now our database is configured we have to create it and migrate our schema by running
+
+```shell
+% HANAMI_ENV=test bundle exec db prepare
+```
+
+As you can see, we have set `HANAMI_ENV` environment variable to instruct our command about the environment to use.
 
 ### Following a Request
 


### PR DESCRIPTION
This commit is intended to help people with setting up their database to run their tests.

Hanami is all about TDD / BDD and there's a strong emphasis on how to write tests but there's a missing part about how to configure the test database so new comers can be stuck with an error message telling them that a database is missing even if they followed the getting started guide step by step.

With these explanation the gap is filled.