### PR TITLE
Use a word 'initialized' instead of 'initialised'

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -436,7 +436,7 @@ We can verify it all works as expected with a unit test:
 require 'spec_helper'
 
 describe Book do
-  it 'can be initialised with attributes' do
+  it 'can be initialized with attributes' do
     book = Book.new(title: 'Refactoring')
     book.title.must_equal 'Refactoring'
   end


### PR DESCRIPTION
Thank you for your nice documents.

I found a small improvement in the Getting Started page.

I think it is better to use a word `initialize` instead of `initialise` because the previous description (... which we pass to initialize params) uses it.
Also, `initialize` is a very popular method name in Ruby.