### PR TITLE
avoid test failure by using books_path

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -1073,7 +1073,7 @@ We can use the `routes` helper method that is available in our views and actions
 We can make a similar change in `apps/web/controllers/books/create.rb`:
 
 ```ruby
-redirect_to routes.books_url
+redirect_to routes.books_path
 ```
 
 ## Wrapping Up


### PR DESCRIPTION
By following the guide and using the `books_url` routes helper, instead of `books_path`, the action test fails:

```
  1) Failure:
Web::Controllers::Books::Create::with valid params#test_0002_redirects the user to the books listing [/home/tpavel/workspace/bookshelf/spec/web/controllers/books/create_spec.rb:27]:
Expected: "/books"
  Actual: "http://0.0.0.0:2300/books"
```

I see `books_path` is used in the corresponding commit in the [hanami/bookshelf repo](https://github.com/hanami/bookshelf/commit/7a99bb50a87449d2e9794a2498de751f4fc9b4a7), so this PR should keep things consistent.