### PR TITLE
Add hint that mailers folder is now required

### DIFF
--- a/source/guides/upgrade-notes/v100.md
+++ b/source/guides/upgrade-notes/v100.md
@@ -50,6 +50,7 @@ Hanami.configure do
   end
 
   mailer do
+    # Make sure this folder exists, or delete this row.
     root Hanami.root.join("lib", "bookshelf", "mailers")
 
     # This has changed. It used to be a block, now it's a setting


### PR DESCRIPTION
See https://github.com/hanami/hanami/issues/767
@jodosha turns out one could also remove the line specifying the mailer root folder.

I think a simple inline hint should suffice. WDYT?