### PR TITLE
use consistent expectation for redirect location

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -765,7 +765,7 @@ describe Web::Controllers::Books::Create do
     response = action.call(params)
 
     response[0].must_equal 302
-    response[1]['Location'].must_include '/books'
+    response[1]['Location'].must_equal '/books'
   end
 end
 ```


### PR DESCRIPTION
Related PR: #320

As discussed in previous PR, the expectation for redirect location should be strict and consistent across versions of the test before and after refactoring.