### PR TITLE
Fix example for check constraint code

### DIFF
--- a/source/guides/migrations/create-table.md
+++ b/source/guides/migrations/create-table.md
@@ -145,6 +145,6 @@ create_table :users do
   column :role, String
 
   check { age > 18 }
-  check %(role IN("contributor", "manager", "owner"))
+  check %(role IN('contributor', 'manager', 'owner'))
 end
 ```


### PR DESCRIPTION
I have migration:
```ruby
Hanami::Model.migration do
  change do
    create_table :coupons do
      primary_key :id

      column :type,   String
      # ..

      check %(type IN('fixed', 'percent'))
    end
  end
end
```

## With double quotes
```
[hanami] [INFO] (0.000143s) ROLLBACK
/Users/anton/.rvm/gems/ruby-2.3.0/gems/sequel-4.45.0/lib/sequel/adapters/postgres.rb:191:in `async_exec': PG::UndefinedObject: ERROR:  type "str" does not exist (Sequel::DatabaseError)
```

/cc @hanami/core 