### PR TITLE
Fix example of Entity instantiation

### DIFF
--- a/source/guides/models/entities.md
+++ b/source/guides/models/entities.md
@@ -126,7 +126,7 @@ end
 Let's instantiate it with proper values:
 
 ```ruby
-user = User.new(name: "Luca", age: 34, email: "test@hanami.test")
+user = User.new(name: "Luca", age: 34, email: "luca@hanami.test")
 
 user.name     # => "Luca"
 user.age      # => 34


### PR DESCRIPTION
The email used for instantiating User was not matching the expected email.
We're now using `luca@hanami.test` everywhere.

## Before

```ruby
user = User.new(name: "Luca", age: 34, email: "test@hanami.test")

# [...]
user.email    # => "luca@hanami.test"
```

## After

```ruby
user = User.new(name: "Luca", age: 34, email: "luca@hanami.test")

# [...]
user.email    # => "luca@hanami.test"
```