### PR TITLE
Fix Escape Helpers link in Guides HTML5 Helpers

### DIFF
--- a/source/guides/helpers/html5.md
+++ b/source/guides/helpers/html5.md
@@ -184,7 +184,7 @@ end
   # => "<div><p>&lt;script&gt;alert(&apos;xss&apos;)&lt;&#x2F;script&gt;</p></div>"
 ```
 
-**HTML attributes aren't automatically escaped**, in case we need to use a value that comes from a user input, we suggest to use `#ha`, which is the escape helper designed for this case. See [Escape Helpers](`/guides/helpers/escape`) for a deep explanation.
+**HTML attributes aren't automatically escaped**, in case we need to use a value that comes from a user input, we suggest to use `#ha`, which is the escape helper designed for this case. See [Escape Helpers](/guides/helpers/escape) for a deep explanation.
 
 ## View Context
 


### PR DESCRIPTION
The link to Escape Helpers page is broken on HTML5 helpers page.
See http://hanamirb.org/guides/helpers/html5/

- Broken link: http://hanamirb.org/guides/helpers/html5/%60/guides/helpers/escape%60 (404 page)
- Correct link: http://hanamirb.org/guides/helpers/escape/
