### PR TITLE
Fix Guides - Request and Response page

### DIFF
--- a/source/guides/actions/request-and-response.md
+++ b/source/guides/actions/request-and-response.md
@@ -29,7 +29,7 @@ end
 
 <p class="warning">
   Instantiating a <code>request</code> for each incoming HTTP request can lead to minor performance degradation.
-  As an alternative, please consider getting the same information from private action methods like <code>accepts?</code> or from the raw Rack environment <code>params.env</code>.
+  As an alternative, please consider getting the same information from private action methods like <code>accept?</code> or from the raw Rack environment <code>params.env</code>.
 </p>
 
 # Response


### PR DESCRIPTION
Small typo here, we should use `accept?` method instead of `accepts?` method: there is no `s`.

I'm new to the framework so here I guess it refers to this method 👉 https://github.com/hanami/controller/blob/master/lib/hanami/action/mime.rb#L488-L492