### PR TITLE
Update getting started guide

### DIFF
--- a/source/guides/getting-started.md
+++ b/source/guides/getting-started.md
@@ -830,7 +830,7 @@ describe Web::Controllers::Books::Create do
   describe 'with valid params' do
     let(:params) { Hash[book: { title: 'Confident Ruby', author: 'Avdi Grimm' }] }
 
-    it 'is creates a book' do
+    it 'creates a book' do
       action.call(params)
       book = repository.last
 
@@ -994,8 +994,7 @@ Open up `apps/web/templates/books/new.html.erb`:
 <% end %>
 ```
 
-As you can see, in this case we simply hard-code the error message "is required", but you could inspect the error and customise your message for the specific validation that failed.
-This will be improved in the near future.
+Run your tests again and see they are all passing again!
 
 ```shell
 % bundle exec rake


### PR DESCRIPTION
I was going through the guide and this part surprised me

> As you can see, in this case we simply hard-code the error message "is required", but you could inspect the error and customise your message for the specific validation that failed

because the guide didn't hardcode "is required" it looped over `param.errors` and showed proper error messages.

Wasnt sure what to replace it with, so I copy pasted the "run your tests again" message from the section above since the code snippet below is running the tests.