### PR TITLE
Update link to migration generator

### DIFF
--- a/source/guides/1.0/migrations/overview.md
+++ b/source/guides/1.0/migrations/overview.md
@@ -6,7 +6,7 @@ version: 1.0
 # Migrations
 
 Migrations are a feature that allows to manage database schema via Ruby.
-They come with some [command line facilities](/guides/1.0/command-line/database) that allow to perform database operations or to [generate](/guides/1.0/command-line/generators) migrations.
+They come with some [command line facilities](/guides/1.0/command-line/database) that allow to perform database operations or to [generate](/guides/1.0/command-line/generators/#migrations) migrations.
 
 Migrations are only available if our application uses the [SQL adapter](/guides/1.0/models/overview).
 

--- a/source/guides/head/migrations/overview.md
+++ b/source/guides/head/migrations/overview.md
@@ -6,7 +6,7 @@ version: head
 # Migrations
 
 Migrations are a feature that allows to manage database schema via Ruby.
-They come with some [command line facilities](/guides/head/command-line/database) that allow to perform database operations or to [generate](/guides/head/command-line/generators) migrations.
+They come with some [command line facilities](/guides/head/command-line/database) that allow to perform database operations or to [generate](/guides/head/command-line/generators/#migrations) migrations.
 
 Migrations are only available if our application uses the [SQL adapter](/guides/head/models/overview).
 


### PR DESCRIPTION
On [Migration Overview](http://hanamirb.org/guides/1.0/migrations/overview/) page, just make sure that the link to the **migration generator** goes directly at the `#migrations` anchor, [here](http://hanamirb.org/guides/1.0/command-line/generators/#migrations).

I made the change for both `1.0` and `head` versions.