### PR TITLE
Update Routing helpers in guides

### DIFF
--- a/source/guides/1.0/helpers/routing.md
+++ b/source/guides/1.0/helpers/routing.md
@@ -62,3 +62,7 @@ end
 ```
 
 In the case above, we have passed a Hash as set of params that are required to generate the URL.
+
+<p class="convention">
+  Absolute URL generation is dependent on <code>scheme</code>, <code>host</code> and <code>port</code> settings in <code>apps/web/application.rb</code>.
+</p>

--- a/source/guides/head/helpers/routing.md
+++ b/source/guides/head/helpers/routing.md
@@ -62,3 +62,7 @@ end
 ```
 
 In the case above, we have passed a Hash as set of params that are required to generate the URL.
+
+<p class="convention">
+  Absolute URL generation is dependent on <code>scheme</code>, <code>host</code> and <code>port</code> settings in <code>apps/web/application.rb</code>.
+</p>


### PR DESCRIPTION
I was searching on how to configure `host` and other settings for absolute URLs. But when using the search form and searching for `url` or `absolute urls`, it points only to  [Routing helpers](http://hanamirb.org/guides/1.0/helpers/routing/) page. 

On this page, there is no mention on how absolute URLs are generated: using `scheme`, `host` and `port` settings.

I updated this page by taking the sentence from [Routing - basic usage](http://hanamirb.org/guides/routing/basic-usage/#named-routes) page.

Sometimes the information is there but not exactly where we are looking at =)