### PR TITLE
Fix incorrect usage in guides/actions/control_flow

### DIFF
--- a/source/guides/1.0/actions/control-flow.md
+++ b/source/guides/1.0/actions/control-flow.md
@@ -258,5 +258,5 @@ Sometimes you'll want to `redirect_to` back in your browser's history so the eas
 is the following way:
 
 ```ruby
-redirect_to request.headers["Referer"] || fallback_url
+redirect_to request.get_header("Referer") || fallback_url
 ```

--- a/source/guides/head/actions/control-flow.md
+++ b/source/guides/head/actions/control-flow.md
@@ -258,5 +258,5 @@ Sometimes you'll want to `redirect_to` back in your browser's history so the eas
 is the following way:
 
 ```ruby
-redirect_to request.headers["Referer"] || fallback_url
+redirect_to request.get_header("Referer") || fallback_url
 ```


### PR DESCRIPTION
There is no method `request#headers[]` according to below.

- https://github.com/hanami/controller/blob/master/lib/hanami/action/request.rb
- http://www.rubydoc.info/gems/rack/Rack/Request/Env#get_header-instance_method

So, I fixed the example to valid one.