### PR TITLE
Fix share code page in Views guide

### DIFF
--- a/source/guides/1.0/views/share-code.md
+++ b/source/guides/1.0/views/share-code.md
@@ -33,7 +33,7 @@ Then we can load the file and include the module in **all** the views of our app
 
 ```ruby
 # apps/web/application.rb
-require_relative './accept_json'
+require_relative './views/accept_json'
 
 module Web
   class Application < Hanami::Application

--- a/source/guides/head/views/share-code.md
+++ b/source/guides/head/views/share-code.md
@@ -33,7 +33,7 @@ Then we can load the file and include the module in **all** the views of our app
 
 ```ruby
 # apps/web/application.rb
-require_relative './accept_json'
+require_relative './views/accept_json'
 
 module Web
   class Application < Hanami::Application


### PR DESCRIPTION
In the example on the [Views share code](http://hanamirb.org/guides/1.0/views/share-code/) page, the shared file is stored at `apps/web/views/accept_json.rb` and we require it from `apps/web/application.rb`.

Thus the require relative is not pointing at the correct path, it's missing the `views` folder.

I've updated both 1.0 and head versions.