### PR TITLE
Mention PostgreSQL types in Migration data types page

### DIFF
--- a/source/guides/1.0/migrations/create-table.md
+++ b/source/guides/1.0/migrations/create-table.md
@@ -50,7 +50,10 @@ It supports the following options:
   * `:primary_key` (make the column primary key for the table)
   * `:unique` (add a uniqueness constraint for the column)
 
-
+<p class="convention">
+  Note that Hanami natively supports <strong>PostgreSQL data types</strong>.
+  Learn more about them in the <a href="/guides/1.0/models/postgresql/">dedicated article</a>.
+</p>
 
 #### Primary Key
 

--- a/source/guides/head/migrations/create-table.md
+++ b/source/guides/head/migrations/create-table.md
@@ -50,7 +50,10 @@ It supports the following options:
   * `:primary_key` (make the column primary key for the table)
   * `:unique` (add a uniqueness constraint for the column)
 
-
+<p class="convention">
+  Note that Hanami natively supports <strong>PostgreSQL data types</strong>.
+  Learn more about them in the <a href="/guides/head/models/postgresql/">dedicated article</a>.
+</p>
 
 #### Primary Key
 

--- a/source/stylesheets/guides.css
+++ b/source/stylesheets/guides.css
@@ -537,6 +537,9 @@ body {
   border-color: #3498db;
   background-color: #67cbfe;
 }
+.convention a {
+  color: #fff;
+}
 .warning {
   border-color: #f39c12;
   background-color: #f1c40f;


### PR DESCRIPTION
When looking for wich data type I can use in a migration, I know that it must be somewhere in the Migrations section. And yes, I find the information here in the [Migrations create table](http://hanamirb.org/guides/1.0/migrations/create-table/) page.

But I keep forgetting that there are extra data types for PostgreSQL that are mentionned elsewhere, here in [Models PostgreSQL](http://hanamirb.org/guides/1.0/models/postgresql/).

So I've added a mention to this page on **Migrations create** table page.

BTW does it make sense to have [PostgreSQL](http://hanamirb.org/guides/1.0/models/postgresql/) page inside the **Models** category? From what I see, it's mostly about PostgreSQL migrations. What do you think?

PS: the default purple link didn't look nice inside the convention paragraph. I turned it into white color but I'm not sure how CSS is structured. So I've added a property at the end of `source/stylesheets/guides.css` file.