### PR TITLE
Fix typo in Repositories guide

### DIFF
--- a/source/guides/1.0/models/repositories.md
+++ b/source/guides/1.0/models/repositories.md
@@ -135,7 +135,7 @@ This is a **huge improvement**, because:
 
 To have a track of when a record has been created or updated is important when running a project in production.
 
-When creating a new table, if we add the following columns, a repository will take care of keep the values updated.
+When creating a new table, if we add the following columns, a repository will take care of keeping the values updated.
 
 ```ruby
 Hanami::Model.migration do

--- a/source/guides/head/models/repositories.md
+++ b/source/guides/head/models/repositories.md
@@ -116,7 +116,7 @@ This is a **huge improvement**, because:
 
 To have a track of when a record has been created or updated is important when running a project in production.
 
-When creating a new table, if we add the following columns, a repository will take care of keep the values updated.
+When creating a new table, if we add the following columns, a repository will take care of keeping the values updated.
 
 ```ruby
 Hanami::Model.migration do


### PR DESCRIPTION
Quick fix in [Repositories](http://hanamirb.org/guides/1.0/models/repositories/#timestamps) guide. 
It should be "take care of keeping" instead of "take care of keep".