### PR TITLE
Add mention to ROM and Sequel in Repositories guide

### DIFF
--- a/source/guides/1.0/models/repositories.md
+++ b/source/guides/1.0/models/repositories.md
@@ -131,6 +131,19 @@ This is a **huge improvement**, because:
 
   * If we change the storage, the callers aren't affected.
 
+<div class="convention">
+  <p>
+    Hanami queries are based on gems from <strong>ROM</strong> project, namely
+    <code>rom-repository</code> and <code>rom-sql</code>.
+    The gem <code>rom-sql</code> is itself based on <strong>Sequel</strong> project.
+  </p>
+  <p>
+    Learn more on how to craft queries with
+    <a href="http://rom-rb.org/current/learn/sql/queries/">ROM</a>
+    and <a href="http://sequel.jeremyevans.net/documentation.html">Sequel</a>.
+  </p>
+</div>
+
 ## Timestamps
 
 To have a track of when a record has been created or updated is important when running a project in production.

--- a/source/guides/head/models/repositories.md
+++ b/source/guides/head/models/repositories.md
@@ -112,6 +112,19 @@ This is a **huge improvement**, because:
 
   * If we change the storage, the callers aren't affected.
 
+<div class="convention">
+  <p>
+    Hanami queries are based on gems from <strong>ROM</strong> project, namely
+    <code>rom-repository</code> and <code>rom-sql</code>.
+    The gem <code>rom-sql</code> is itself based on <strong>Sequel</strong> project.
+  </p>
+  <p>
+    Learn more on how to craft queries with
+    <a href="http://rom-rb.org/current/learn/sql/queries/">ROM</a>
+    and <a href="http://sequel.jeremyevans.net/documentation.html">Sequel</a>.
+  </p>
+</div>
+
 ## Timestamps
 
 To have a track of when a record has been created or updated is important when running a project in production.

--- a/source/stylesheets/guides.css
+++ b/source/stylesheets/guides.css
@@ -539,6 +539,10 @@ body {
 }
 .convention a {
   color: #fff;
+  font-weight: 700;
+}
+.convention p:last-child {
+  margin-bottom: 0;
 }
 .warning {
   border-color: #f39c12;


### PR DESCRIPTION
I'm often struggling to create rather "complex" SQL queries (eg. joins, order desc, average, etc.) with Hanami repository. And I often end up with a mix of ROM and exceptionally Sequel syntax (eg. when having to qualify a column).

I think it could be nice to provide links to ROM and Sequel documentations in the [Repository](http://hanamirb.org/guides/1.0/models/repositories/#private-queries) guide as mentioned here https://github.com/hanami/hanami.github.io/issues/309#issuecomment-300313160

Here is a screenshot of the block I've added 👇 

![mention-rom-n-sequel](https://user-images.githubusercontent.com/50518/31120946-9a42020e-a836-11e7-8b57-142f170712a2.png)
