### PR TITLE
Remove unused compass config

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -20,18 +20,6 @@ end
 activate :breadcrumbs
 
 ###
-# Compass
-###
-
-compass_config do |config|
-  config.output_style    = :compact
-  config.http_path       = '/'
-  config.css_dir         = 'source/stylesheets'
-  config.images_dir      = 'source/images'
-  config.javascripts_dir = 'source/javascripts'
-end
-
-###
 # Page options, layouts, aliases and proxies
 ###
 


### PR DESCRIPTION
Compass is not being used thus it could be safe to remove. Plus compass is extracted to middleman-compass in v4 of compass due to its stagnation in development and support.

