### PR TITLE
Center aligning company logos for more space between them

### DIFF
--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -84,7 +84,7 @@
             <p class="lead m-x-auto">Trusted by</p>
           </div>
         </div>
-        <div class="row">
+        <div class="row text-center">
           <div class="col-sm-4">
             <a href="https://dnsimple.com/opensource" rel="noopener noreferrer" target="_blank">
               <img src="/images/companies/dnsimple.png" alt="DNSimple">


### PR DESCRIPTION
Before:
<img width="1092" alt="screen shot 2017-12-05 at 07 58 48" src="https://user-images.githubusercontent.com/1516771/33593959-2547494a-d992-11e7-9df4-12487f7f1406.png">

After:
<img width="1166" alt="screen shot 2017-12-05 at 07 58 01" src="https://user-images.githubusercontent.com/1516771/33593939-0d60a222-d992-11e7-86af-745374cb3f66.png">
