### PR TITLE
Improve section about using own ORM

### DIFF
--- a/source/guides/1.0/models/use-your-own-orm.md
+++ b/source/guides/1.0/models/use-your-own-orm.md
@@ -12,8 +12,7 @@ Here's how to do it:
 
   1. Edit your `Gemfile`, remove `hanami-model`, add the gem(s) of your ORM and run `bundle install`.
   2. Remove `lib/` directory (eg. `rm -rf lib`).
-  3. Edit `config/environment.rb`, then remove `require_relative '../lib/bookshelf'` and `model` block in `Hanami.configure`
-  4. Edit `Rakefile` and remove `require 'hanami/rake_tasks'`.
+  3. Open `config/environment.rb`, then remove `require 'hanami/model'`, `require_relative '../lib/bookshelf'` (`bookshelf` should be name of your project) and `model` block in `Hanami.configure`
+  4. Open `Rakefile` and remove `require 'hanami/rake_tasks'`.
 
 Please notice that if `hanami-model` is removed from the project features like [database commands](/guides/1.0/command-line/database) and [migrations](/guides/1.0/migrations/overview) aren't available.
-

--- a/source/guides/1.0/models/use-your-own-orm.md
+++ b/source/guides/1.0/models/use-your-own-orm.md
@@ -11,7 +11,7 @@ This level of separation allows you to use the ORM (data layer) of your choice.
 Here's how to do it:
 
   1. Edit your `Gemfile`, remove `hanami-model`, add the gem(s) of your ORM and run `bundle install`.
-  2. Remove `lib/` directory (eg. `rm -rf lib`).
+  2. Remove `lib/` directory (eg. `rm -rf lib`). Either keep `lib/bookshelf/mailers` or also remove `mailer` block in step 3.
   3. Open `config/environment.rb`, then remove `require 'hanami/model'`, `require_relative '../lib/bookshelf'` (`bookshelf` should be name of your project) and `model` block in `Hanami.configure`
   4. Open `Rakefile` and remove `require 'hanami/rake_tasks'`.
 

--- a/source/guides/1.1/models/use-your-own-orm.md
+++ b/source/guides/1.1/models/use-your-own-orm.md
@@ -11,7 +11,7 @@ This level of separation allows you to use the ORM (data layer) of your choice.
 Here's how to do it:
 
   1. Edit your `Gemfile`, remove `hanami-model`, add the gem(s) of your ORM and run `bundle install`.
-  2. Remove `lib/` directory (eg. `rm -rf lib`).
+  2. Remove `lib/` directory (eg. `rm -rf lib`). Either keep `lib/bookshelf/mailers` or also remove `mailer` block in step 3.
   3. Open `config/environment.rb`, then remove `require 'hanami/model'`, `require_relative '../lib/bookshelf'` (`bookshelf` should be name of your project) and `model` block in `Hanami.configure`.
   4. Open `Rakefile` and remove `require 'hanami/rake_tasks'`.
 

--- a/source/guides/1.1/models/use-your-own-orm.md
+++ b/source/guides/1.1/models/use-your-own-orm.md
@@ -12,8 +12,7 @@ Here's how to do it:
 
   1. Edit your `Gemfile`, remove `hanami-model`, add the gem(s) of your ORM and run `bundle install`.
   2. Remove `lib/` directory (eg. `rm -rf lib`).
-  3. Edit `config/environment.rb`, then remove `require_relative '../lib/bookshelf'` and `model` block in `Hanami.configure`
-  4. Edit `Rakefile` and remove `require 'hanami/rake_tasks'`.
+  3. Open `config/environment.rb`, then remove `require 'hanami/model'`, `require_relative '../lib/bookshelf'` (`bookshelf` should be name of your project) and `model` block in `Hanami.configure`.
+  4. Open `Rakefile` and remove `require 'hanami/rake_tasks'`.
 
 Please notice that if `hanami-model` is removed from the project features like [database commands](/guides/1.1/command-line/database) and [migrations](/guides/1.1/migrations/overview) aren't available.
-


### PR DESCRIPTION
* Add missing info about need to delete `require 'hanami/model'`
* Add note stating that `bookshelf` should be name of the project in
  practice