### PR TITLE
Fix mailer custom delivery method example

### DIFF
--- a/source/guides/1.0/mailers/delivery.md
+++ b/source/guides/1.0/mailers/delivery.md
@@ -108,7 +108,7 @@ Hanami.configure do
     # ...
 
     mailer do
-      production MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
+      delivery MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
     end
   end
 end

--- a/source/guides/1.1/mailers/delivery.md
+++ b/source/guides/1.1/mailers/delivery.md
@@ -108,7 +108,7 @@ Hanami.configure do
     # ...
 
     mailer do
-      production MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
+      delivery MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
     end
   end
 end


### PR DESCRIPTION
This PR fixes an error on the [Mailer Custom Method](http://hanamirb.org/guides/1.0/mailers/delivery/) documentation.

### Before

```ruby
mailer do
  production MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
end
```

### After

```ruby
mailer do
  delivery MandrillDeliveryMethod, api_key: ENV['MANDRILL_API_KEY']
end
```