### PR TITLE
[WIP] Change Getting Started to use RSpec

### DIFF
--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -66,7 +66,7 @@ Then we can use the new `hanami` executable to generate a new project:
 
 ```
 % gem install hanami
-% hanami new bookshelf
+% hanami new bookshelf --test=rspec
 ```
 
 <p class="notice">
@@ -150,7 +150,7 @@ describe 'Visit home' do
   it 'is successful' do
     visit '/'
 
-    page.body.must_include('Bookshelf')
+    expect(page).to have_content('Bookshelf')
   end
 end
 ```
@@ -271,7 +271,7 @@ describe 'List books' do
     visit '/books'
 
     within '#books' do
-      assert page.has_css?('.book', count: 2), 'Expected to find 2 books'
+      expect(page).to have_css('.book', count: 2)
     end
   end
 end
@@ -440,7 +440,7 @@ require 'spec_helper'
 describe Book do
   it 'can be initialized with attributes' do
     book = Book.new(title: 'Refactoring')
-    book.title.must_equal 'Refactoring'
+    expect(book.title).to eq('Refactoring')
   end
 end
 ```
@@ -516,12 +516,12 @@ describe Web::Views::Books::Index do
   let(:rendered)  { view.render }
 
   it 'exposes #books' do
-    view.books.must_equal exposures.fetch(:books)
+    expect(view.books).to eq(exposures.fetch(:books))
   end
 
   describe 'when there are no books' do
     it 'shows a placeholder message' do
-      rendered.must_include('<p class="placeholder">There are no books yet.</p>')
+      expect(rendered).to include('<p class="placeholder">There are no books yet.</p>')
     end
   end
 
@@ -531,13 +531,13 @@ describe Web::Views::Books::Index do
     let(:exposures) { Hash[books: [book1, book2]] }
 
     it 'lists them all' do
-      rendered.scan(/class="book"/).count.must_equal 2
-      rendered.must_include('Refactoring')
-      rendered.must_include('Domain Driven Design')
+      expect(rendered.scan(/class="book"/).length).to eq(2)
+      expect(rendered).to include('Refactoring')
+      expect(rendered).to include('Domain Driven Design')
     end
 
     it 'hides the placeholder message' do
-      rendered.wont_include('<p class="placeholder">There are no books yet.</p>')
+      expect(rendered).to_not include('<p class="placeholder">There are no books yet.</p>')
     end
   end
 end
@@ -589,7 +589,7 @@ describe Web::Controllers::Books::Index do
 
   it 'is successful' do
     response = action.call(params)
-    response[0].must_equal 200
+    expect(response[0]).to eq(200)
   end
 
   it 'exposes all books' do
@@ -660,8 +660,8 @@ describe 'Add a book' do
       click_button 'Create'
     end
 
-    current_path.must_equal('/books')
-    assert page.has_content?('New book')
+    expect(page).to have_current_path('/books')
+    expect(page).to have_content('New book')
   end
 end
 ```
@@ -755,15 +755,14 @@ describe Web::Controllers::Books::Create do
     action.call(params)
     book = repository.last
 
-    book.id.wont_be_nil
-    book.title.must_equal params.dig(:book, :title)
+    expect(book.id).to_not be_nil
   end
 
   it 'redirects the user to the books listing' do
     response = action.call(params)
 
-    response[0].must_equal 302
-    response[1]['Location'].must_equal '/books'
+    expect(response[0]).to eq(302)
+    expect(response[1]['Location']).to eq('/books')
   end
 end
 ```
@@ -831,19 +830,19 @@ describe Web::Controllers::Books::Create do
   describe 'with valid params' do
     let(:params) { Hash[book: { title: 'Confident Ruby', author: 'Avdi Grimm' }] }
 
-    it 'creates a book' do
+    it 'creates a new book' do
       action.call(params)
       book = repository.last
 
-      book.id.wont_be_nil
-      book.title.must_equal params.dig(:book, :title)
+      expect(book.id).to_not be_nil
+      expect(book.title).to eq(params.dig(:book, :title))
     end
 
     it 'redirects the user to the books listing' do
       response = action.call(params)
 
-      response[0].must_equal 302
-      response[1]['Location'].must_equal '/books'
+      expect(response[0]).to eq(302)
+      expect(response[1]['Location']).to eq('/books')
     end
   end
 
@@ -852,15 +851,15 @@ describe Web::Controllers::Books::Create do
 
     it 'returns HTTP client error' do
       response = action.call(params)
-      response[0].must_equal 422
+      expect(response[0]).to eq(422)
     end
 
     it 'dumps errors in params' do
       action.call(params)
       errors = action.params.errors
 
-      errors.dig(:book, :title).must_equal  ['is missing']
-      errors.dig(:book, :author).must_equal ['is missing']
+      expect(errors.dig(:book, :title)).to eq(['is missing'])
+      expect(errors.dig(:book, :author)).to eq(['is missing'])
     end
   end
 end

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -84,6 +84,7 @@ Let's see what it contains:
 % tree -L 1
 .
 ├── Gemfile
+├── README.md
 ├── Rakefile
 ├── apps
 ├── config
@@ -93,12 +94,13 @@ Let's see what it contains:
 ├── public
 └── spec
 
-6 directories, 3 files
+6 directories, 4 files
 ```
 
 Here's what we need to know:
 
 * `Gemfile` defines our Rubygems dependencies (using Bundler).
+* `README.md` tells us how to setup and use the project.
 * `Rakefile` describes our Rake tasks.
 * `apps` contains one or more web applications compatible with Rack.
   Here we can find the first generated Hanami application called `Web`.

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -395,14 +395,14 @@ Let's fix that repetition, to show how that works.
 
 ### Layouts
 
-To avoid repeating ourselves in every single template, we can use a layout.
-Open up the file `apps/web/templates/application.html.erb` and edit it to look like this:
+To avoid repeating ourselves in every single template, we can modify our layout template.
+Let's edit `apps/web/templates/application.html.erb` to look like this:
 
 ```rhtml
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Bookshelf</title>
+    <title>Web</title>
     <%= favicon %>
   </head>
   <body>
@@ -412,9 +412,10 @@ Open up the file `apps/web/templates/application.html.erb` and edit it to look l
 </html>
 ```
 
-Now you can remove the duplicate lines from the other templates.
+And remove the duplicate lines from the other templates,
+since they're duplicated now.
 
-A **layout** is like any other template, but it is used to wrap your regular templates.
+A **layout template** is like any other template, but it is used to wrap your regular templates.
 The `yield` line is replaced with the contents of our regular template.
 It's the perfect place to put our repeating headers and footers.
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -156,8 +156,8 @@ _(Hanami architecture is heavily inspired by [Clean Architecture](https://blog.8
 
 ## Writing Our First Test
 
-The opening screen we see when we point our browser at our app, is a
-default page which is displayed when there are no routes defined.
+The opening screen we see when we point our browser at our app,
+is a default page which is displayed when there are no routes defined.
 
 Hanami encourages [Behavior Driven Development](https://en.wikipedia.org/wiki/Behavior-driven_development) (BDD) as a way to write web applications.
 In order to get our first custom page to display, we'll write a high-level feature test:
@@ -175,14 +175,10 @@ describe 'Visit home' do
 end
 ```
 
-Note that, although Hanami is ready for a Behavior Driven Development workflow out of the box, **it is in no way bound to any particular testing framework** -- nor does it come with special integrations or libraries.
-
-We'll go with [Minitest](https://github.com/seattlerb/minitest) here (which is the default), but we can use [RSpec](http://rspec.info) by creating the project with `--test=rspec` option.
-Hanami will then generate helpers and stub files for it.
-
-<p class="notice">
-  Please check .env.test in case you need to tweak the database URL.
-</p>
+Hanami is ready for a Behavior Driven Development workflow out of the box,
+but **it is in no way bound to any particular testing framework**.
+It does not come with any special testing integrations or libraries,
+so if you know RSpec (or Minitest), there's nothing new to learn there.
 
 We have to migrate our schema in the test database by running:
 
@@ -190,7 +186,13 @@ We have to migrate our schema in the test database by running:
 % HANAMI_ENV=test bundle exec hanami db prepare
 ```
 
-As you can see, we have set `HANAMI_ENV` environment variable to instruct our command about the environment to use.
+The `HANAMI_ENV` at the beginning is an environment variable,
+which tells Hanami to use the `test` environment.
+This is necessary here because the default is `HANAMI_ENV=development`.
+
+<p class="notice">
+  If you have trouble, your <tt>DATABASE_URL</tt> is defined in <tt>.env.test</tt>
+</p>
 
 ### Following a Request
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -200,23 +200,25 @@ Now we have a test, we can see it fail:
 
 ```
 % rake test
-Run options: --seed 44759
+F.
 
-# Running:
+Failures:
 
-F
+  1) Visit home is successful
+     Failure/Error: expect(page).to have_content('Bookshelf')
+       expected to find text "Bookshelf" in "404 - Not Found"
+     # ./spec/web/features/visit_home_spec.rb:7:in `block (2 levels) in <top (required)>'
 
-Finished in 0.018611s, 53.7305 runs/s, 53.7305 assertions/s.
+Finished in 0.02604 seconds (files took 1.14 seconds to load)
+2 examples, 1 failure
 
-  1) Failure:
-Homepage#test_0001_is successful [/Users/hanami/bookshelf/spec/web/features/visit_home_spec.rb:6]:
-Expected "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Not Found</title>\n  </head>\n  <body>\n    <h1>Not Found</h1>\n  </body>\n</html>\n" to include "Bookshelf".
+Failed examples:
 
-1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
+rspec ./spec/web/features/visit_home_spec.rb:4 # Visit home is successful
 ```
 
 Now let's make it pass.
-Lets add the code required to make this test pass, step-by-step.
+We'll add the code required to make this test pass, step-by-step.
 
 The first thing we need to add is a route:
 
@@ -225,8 +227,12 @@ The first thing we need to add is a route:
 root to: 'home#index'
 ```
 
-We pointed our application's root URL to the `index` action of the `home` controller (see the [routing guide](/guides/1.1/routing/overview) for more information).
-Now we can create the index action.
+We pointed our app's root URL to the `index` action of the `home` controller
+(see the [routing guide](/guides/1.1/routing/overview) for more information).
+
+If we run our tests, we'll get an error that the endpoint cannot be found.
+
+That makes sense, because we need to create the `home#index` action.
 
 ```ruby
 # apps/web/controllers/home/index.rb
@@ -240,8 +246,10 @@ module Web::Controllers::Home
 end
 ```
 
-This is an empty action that doesn't implement any business logic.
-Each action has a corresponding view, which is a Ruby object and needs to be added in order to complete the request.
+This is an empty action that doesn't do anything special.
+Each action in Hanami is defined by [its own class](https://en.wikipedia.org/wiki/Single_responsibility_principle), which makes it simple to test and work on.
+And, each action has a corresponding view, which is also defined by its own class.
+This one needs to be added in order to complete the request.
 
 ```ruby
 # apps/web/views/home/index.rb
@@ -252,27 +260,27 @@ module Web::Views::Home
 end
 ```
 
-...which, in turn, is empty and does nothing more than render its template.
-This is the file we need to edit in order to make our test pass. All we need to do is add the bookshelf heading.
+It's also empty, and doesn't do anything special.
+Its only responsibility is to render a template, which is what views do by default.
+
+This template is what we need to add, in order to make our tests pass.
+All we need to do is add the bookshelf heading.
 
 ```erb
 # apps/web/templates/home/index.html.erb
 <h1>Bookshelf</h1>
 ```
 
-Save your changes, run your test again and it now passes. Great!
+Now let's run our test suite again.
 
 ```shell
-Run options: --seed 19286
+..
 
-# Running:
-
-.
-
-Finished in 0.011854s, 84.3600 runs/s, 168.7200 assertions/s.
-
-1 runs, 2 assertions, 0 failures, 0 errors, 0 skips
+Finished in 0.01394 seconds (files took 1.03 seconds to load)
+2 examples, 0 failures
 ```
+
+This means all our tests pass!
 
 ## Generating New Actions
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -284,11 +284,13 @@ This means all our tests pass!
 
 ## Generating New Actions
 
-Let's use our new knowledge about the major Hanami components to add a new action.
-The purpose of our Bookshelf project is to manage books.
+Let's use our new knowledge about Hanami __routes__, __actions__, __views__, and __templates__.
+
+The purpose of our sample Bookshelf project is to manage books.
 
 We'll store books in our database and let the user manage them with our project.
-A first step would be to show a listing of all the books in our system.
+
+Our first step will be list out all the books we know about.
 
 Let's write a new feature test describing what we want to achieve:
 
@@ -307,7 +309,16 @@ describe 'List books' do
 end
 ```
 
-The test is simple enough, and fails because the URL `/books` is not currently recognised in our application. We'll create a new controller action to fix that.
+This test means that when we go to (/books)[http://localhost:2300/books],
+we'll see two HTML elements that have class `book`,
+and both will be inside of an HTML element that has an id of `books`.
+
+Our test suite is `Unable to find visible css "#books"`.
+
+Not only are we missing that element,
+we don't even have a page to put that element on!
+
+Let's create a new action to fix that.
 
 ### Hanami Generators
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -124,17 +124,35 @@ And... bask in the glory of your first Hanami project at
 
 <p><img src="/images/welcome-page.png" alt="Hanami welcome page" class="img-responsive"></p>
 
-## Hanami Architecture
+## Hanami's Architecture
 
-Hanami architecture **can host several Hanami (and Rack) applications in the same Ruby process**.
+Hanami's architecture revolves around your project containing many `apps`.
+These all live together in the same codebase, and are run in the same Ruby process.
 
-These applications live under `apps/`.
-Each of them can be a component of our product, such as the user facing web interface, the admin pane, metrics, HTTP API etc..
+They live under `apps/`.
 
-All these parts are a _delivery mechanism_ to the business logic that lives under `lib/`.
-This is the place where our models are defined, and interact with each other to compose the **features** that our product provides.
+By default, we have a `web` app,
+which can be thought of as the normal, user-facing web interface.
+This is the most popular, so you'll probably want to keep it in your future Hanami projects.
+But, just so you know, there's nothing special or different about this app,
+it's just so common that Hanami generates it for us.
 
-Hanami architecture is heavily inspired by [Clean Architecture](https://blog.8thlight.com/uncle-bob/2012/08/13/the-clean-architecture.html).
+Later (in a real project), we would add other apps,
+such as an `admin` panel, a JSON `api`, or an analytics `dashboard`.
+
+We could also break our `web` app into smaller. Hanami fully supports that, too!
+
+Different `apps` represent __delivery mechanisms__.
+
+That means they're different ways of interacting with the core of your project,
+or the "business logic".
+
+Hanami doesn't want us to [repeat ourselves](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself),
+so that "business logic" is shared.
+Web applications almost always store and interact with data stored in a database.
+Both our 'business logic' and our persistence live in `lib/`.
+
+_(Hanami architecture is heavily inspired by [Clean Architecture](https://blog.8thlight.com/uncle-bob/2012/08/13/the-clean-architecture.html).)_
 
 ## Writing Our First Test
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -322,26 +322,44 @@ Let's create a new action to fix that.
 
 ### Hanami Generators
 
-Hanami ships with various **generators** to save on typing some of the code involved in adding new functionality.
-In our terminal, enter:
+Hanami ships with a number of **generators**.
+These are tools that write some basic code for you, to help us write less code.
 
-```
+In our terminal, let's run:
+
+```shell
 % bundle exec hanami generate action web books#index
 ```
 
-This will generate a new action _index_ in the _books_ controller of the _web_ application.
-It gives us an empty action, view and template; it also adds a default route to `apps/web/config/routes.rb`:
+<p class="notice">
+  If you're using ZSH and that doesn't work
+  (with an error like <tt>zsh: no matches found: books#index</tt>),
+  Hanami lets us write this instead: <tt>hanami generate action web books/index</tt>
+</p>
+
+This does a lot for us:
+
+- Creating an action at `apps/web/controllers/books/index.rb` (and spec for it),
+- Creating a view at `apps/web/views/books/index.rb` (and a spec for it),
+- Creating a template at `apps/web/templates/books/index.html.erb`.
+
+_(If you're confused by 'action' vs. 'controller', here's a tip:
+Hanami only has `action` classes,
+so a controller is just a module to group several related actions together.)_
+
+They files are all pretty much empty.
+They have some basic code in there, so Hanami knows how to use the class.
+Thankfully we don't have to manually create those five files,
+with that specific code in them.
+
+The generator also adds a new route for us in the `web` app's routes file (`apps/web/config/routes.rb`).
 
 ```ruby
 get '/books', to: 'books#index'
 ```
 
-If you're using ZSH, you may get `zsh: no matches found: books#index`. In that case, you can use:
-```
-% hanami generate action web books/index
-```
-
-To make our test pass, we need to edit our newly generated template file in `apps/web/templates/books/index.html.erb`:
+To make our tests pass,
+we need to edit our newly generated template file in `apps/web/templates/books/index.html.erb`:
 
 ```html
 <h1>Bookshelf</h1>
@@ -360,14 +378,20 @@ To make our test pass, we need to edit our newly generated template file in `app
 </div>
 ```
 
-Save your changes and see your tests pass!
+Now our tests pass!
 
-The terminology of controllers and actions might be confusing, so let's clear this up: actions form the basis of our Hanami applications; controllers are mere modules that group several actions together.
-So while the "controller" is _conceptually_ present in our project, in practice we only deal with actions.
+We've used a generator to create a new end-point (page) in our application.
 
-We've used a generator to create a new endpoint in our application.
-But one thing you may have noticed is that our new template contains the same `<h1>` as our `home/index.html.erb` template.
-Let's fix that.
+But, we've started to repeat ourselves.
+
+In both our `books/index.html.erb` template,
+and our `homes/index.html.erb` template from above,
+we have `<h1>Bookshelf</h1>`.
+
+This is not a huge deal, but in a real application,
+we'll likely have a logo or a common navigation shared across all of the pages in our `app`.
+
+Let's fix that repetition, to show how that works.
 
 ### Layouts
 

--- a/source/guides/1.1/getting-started.md
+++ b/source/guides/1.1/getting-started.md
@@ -422,33 +422,41 @@ It's the perfect place to put our repeating headers and footers.
 ## Modeling Our Data With Entities
 
 Hard-coding books in our templates is, admittedly, kind of cheating.
-Let's add some dynamic data to our application.
+Let's add some dynamic data to our application!
 
 We'll store books in our database and display them on our page.
 To do so, we need a way to read and write to our database.
-Enter entities and repositories:
+There are two types of objects that we'll use for this:
 
-* an **entity** is a domain object (eg. `Book`) uniquely identified by its identity.
-* a **repository** mediates between entities and the persistence layer.
+* an **entity** is a domain object (a `Book`) that is uniquely identified by its identity,
+* a **repository** is what we use to persist, retrieve, and delete data for an entity, in the persistence layer.
 
 Entities are totally unaware of the database.
 This makes them **lightweight** and **easy to test**.
 
-For this reason we need a repository to persist the data that a `Book` depends on.
+Since entities are completely decoupled from the database,
+we use repositories to persist the data behind a `Book`.
+
+_(We also use repositories to turn the data from the database back into a `Book`,
+and delete that data, too.)_
+
 Read more about entities and repositories in the [models guide](/guides/1.1/models/overview).
 
-Hanami ships with a generator for models, so let's use it to create a `Book` entity and the corresponding repository:
+Hanami ships with a generator for models,
+so let's use it to create a `Book` entity and its corresponding repository:
 
-```
+```shell
 % bundle exec hanami generate model book
 create  lib/bookshelf/entities/book.rb
 create  lib/bookshelf/repositories/book_repository.rb
-create  db/migrations/20161115110038_create_books.rb
+create  db/migrations/20180115110038_create_books.rb
 create  spec/bookshelf/entities/book_spec.rb
 create  spec/bookshelf/repositories/book_repository_spec.rb
 ```
 
-The generator gives us an entity, a repository, a migration, and accompanying test files.
+The generator gives us an entity, a repository, and their associated test files.
+
+It also gives a database migration.
 
 ### Migrations To Change Our Database Schema
 


### PR DESCRIPTION
For now, using `hanami new bookshelf --test=rspec`, but we anticipate to change RSpec to be the default testing framework for Hanami.

MiniTest is simpler, but it's less familiar to most people.
Additionally, when this was created, Hanami itself used MiniTest.
We've since switched over to RSpec, since we needed some of its more powerful features (and it's what most of use most of the time).

**NOTE**: This is _not_ ready to merge. I need to update the code examples from running the test suite, since MiniTest's output is different than RSpec's. I also need to go through the guide again, to make sure I didn't miss anything else. Just thought I'd open this to push myself to finish this sooner, and maybe get another set of eyes on the changes :) 🌸 