### PR TITLE
Remove <br> and add margin-top to release date

### DIFF
--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -13,8 +13,9 @@
         <div class="app-block-cta">
           <a href="#install" class="btn btn-primary m-t">Install v<%= hanami_version %></a>
           <a href="https://guides.hanamirb.org/getting-started" target="_blank" class="btn btn-default btn-outline m-t">Getting Started</a>
-          <br>
-          <em class="hanami-release-date">Released on <%= hanami_release_date %></em>
+          <p class="hanami-release-date">
+            <em>Released on <%= hanami_release_date %></em>
+          </p>
         </div>
         <img src="/images/home-background.jpg">
       </div>

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -283,6 +283,7 @@ table.status td {
 }
 
 .hanami-release-date {
+  margin-top: 1em;
   font-weight: 200;
   color: #777;
 }


### PR DESCRIPTION
I felt this could stand to have some margin, and I'm not a big fan of the `<br>`.

Before:
![image](https://user-images.githubusercontent.com/11466782/50027365-95a96100-ffb1-11e8-8097-4b301a628a5e.png)

After:
![image](https://user-images.githubusercontent.com/11466782/50027413-bd98c480-ffb1-11e8-8baf-14c6d3b1932f.png)

