### PR TITLE
Remove pointless CSS rule

### DIFF
--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -166,10 +166,6 @@ div.download-develop-deploy code {
   color: #999;
 }
 
-div.app-block-footer {
-  margin-top: 2em;
-}
-
 .app-block-footer .col-sm-6 p {
   color: rgba(116, 119, 123, 0.85);
 }


### PR DESCRIPTION
I noticed this gap and can't see a reason for this CSS rule

Before:
![image](https://user-images.githubusercontent.com/11466782/50027608-6810e780-ffb2-11e8-8dde-9eeaa9f1a6da.png)

After:
![image](https://user-images.githubusercontent.com/11466782/50027569-4879bf00-ffb2-11e8-9402-d087136eff6e.png)
