### PR TITLE
Use native lazy loading on images

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -73,7 +73,7 @@ helpers do
 
   def article_image(article)
     if article.data.image
-      %(<img src="#{ article_image_url(article) }">)
+      %(<img src="#{ article_image_url(article) }" loading="lazy">)
     end
   end
 

--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -34,7 +34,7 @@
         <ul class="list-unstyled list-spaced">
           <a href="http://dnsimple.link/resolving-hanami" target="_blank">
             <span>Resolving with<br/></span>
-            <img src="https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png" alt="DNSimple" style="display:block;margin:0;padding:0;width:100px;"/>
+            <img src="https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png" alt="DNSimple" style="display:block;margin:0;padding:0;width:100px;" loading="lazy"/>
           </a>
         </ul>
       </div>

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -88,17 +88,17 @@
         <div class="row text-center">
           <div class="col-sm-4">
             <a href="https://dnsimple.com/opensource" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/dnsimple.png" alt="DNSimple">
+              <img src="/images/companies/dnsimple.png" alt="DNSimple" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://www.freework.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/freework.png" alt="Freework">
+              <img src="/images/companies/freework.png" alt="Freework" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://www.advanon.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/advanon.png" alt="advanon">
+              <img src="/images/companies/advanon.png" alt="advanon" loading="lazy">
             </a>
           </div>
         </div>
@@ -106,17 +106,17 @@
         <div class="row text-center">
           <div class="col-sm-4">
             <a href="http://hellohippo.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/hippo.png" alt="hippo">
+              <img src="/images/companies/hippo.png" alt="hippo" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://ppe-analytics.com/index_en.html" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/ppe-analytics.png" alt="ppe-analytics">
+              <img src="/images/companies/ppe-analytics.png" alt="ppe-analytics" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://flooringstores.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/flooring-stores.png" alt="flooring-stores">
+              <img src="/images/companies/flooring-stores.png" alt="flooring-stores" loading="lazy">
             </a>
           </div>
         </div>
@@ -124,17 +124,17 @@
         <div class="row text-center">
           <div class="col-sm-4">
             <a href="https://marozed.ma" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/marozed.png" alt="Marozed Web Agency">
+              <img src="/images/companies/marozed.png" alt="Marozed Web Agency" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://ascendaloyalty.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/ascenda-loyalty.png" alt="Ascenda Loyalty">
+              <img src="/images/companies/ascenda-loyalty.png" alt="Ascenda Loyalty" loading="lazy">
             </a>
           </div>
           <div class="col-sm-4">
             <a href="https://playguide.eu" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/playguide.png" alt="PlayGuide">
+              <img src="/images/companies/playguide.png" alt="PlayGuide" loading="lazy">
             </a>
           </div>
         </div>


### PR DESCRIPTION
Current versions of Firefox, Chrome and Edge already supports native lazy loading, and [Safari is coming too](https://blog.josephscott.org/2019/09/30/safari-is-working-on-native-lazy-loading-images/).

https://web.dev/native-lazy-loading/