### PR TITLE
Fix name of deprecated method in v1.3.0 release notes

### DIFF
--- a/source/blog/2018-10-24-announcing-hanami-130.html.markdown
+++ b/source/blog/2018-10-24-announcing-hanami-130.html.markdown
@@ -101,9 +101,9 @@ end
 
 Please use the corresponding webserver (eg. Nginx) feature, a Rack middleware (eg. `rack-ssl-enforcer`), or another strategy to force HTTPS connection.
 
-### Action's parsed_body 🚫
+### Action's parsed_request_body 🚫
 
-We deprecated `Hanami::Action#parsed_body`, and it will be removed in future releases of Hanami.
+We deprecated `Hanami::Action#parsed_request_body`, and it will be removed in future releases of Hanami.
 
 ## Minor Enhancements 🆙
 


### PR DESCRIPTION
The name of the method deprecated in v1.3.0 has a typo - it's actually `Hanami::Action#parsed_request_body` (deprecated [here](https://github.com/hanami/controller/commit/06c79e237d37c19fe26a310dd51acc21cf36f98d)).