### PR TITLE
Fix incorrectly italicized title in v1.3.0 release notes

### DIFF
--- a/source/blog/2018-10-24-announcing-hanami-130.html.markdown
+++ b/source/blog/2018-10-24-announcing-hanami-130.html.markdown
@@ -101,7 +101,7 @@ end
 
 Please use the corresponding webserver (eg. Nginx) feature, a Rack middleware (eg. `rack-ssl-enforcer`), or another strategy to force HTTPS connection.
 
-### Action's parsed_request_body 🚫
+### Action's parsed\_request\_body 🚫
 
 We deprecated `Hanami::Action#parsed_request_body`, and it will be removed in future releases of Hanami.
 


### PR DESCRIPTION
This was my bad - when the deprecated method name was updated in 0f39c61f, Markdown started treating the underscores in `parsed_request_body` as italics.  Escaped the underscores. Tested this by running `bin/site build` locally and the section title shows up correctly. Sorry for the noise!