### PR TITLE
Update lotus announcement link

### DIFF
--- a/source/_lotus.erb
+++ b/source/_lotus.erb
@@ -1,7 +1,7 @@
 <div id="lotus" class="text-xs-center">
   <div class="container">
     <div class="row">
-      Looking for <strong>Lotus</strong>? We renamed the project and it's now called <strong>Hanami</strong>. Read the <a href="/blog/2016/01/22/lotus-is-now-hanami.html">announcement</a>.
+      Looking for <strong>Lotus</strong>? We renamed the project and it's now called <strong>Hanami</strong>. Read the <a href="/blog/2016/01/22/lotus-is-now-hanami">announcement</a>.
     </div>
   </div>
 </div>


### PR DESCRIPTION
Somehow, the link ending with `.html` is not working. Just fixing it