### PR TITLE
Add information about Hanami Mastery initiative

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -37,6 +37,10 @@ title: Community
 <p>The awesome-hanami Github repository lists Hanami gems, libraries and projects that use Hanami. Also, there are some useful links to know more about Hanami and its users.</p>
 <a href="http://awesome-hanami.org" target="_blank">awesome-hanami.org</a>
 
+<h2 class="page-header">Hanami Mastery</h2>
+<p>Hanami Mastery initiative is a collection of <strong>articles and video tutorials</strong> about Hanami and its dependencies, as well as all awesome gems that can be used within Hanami framework.</p>
+<a href="https://hanamimastery.com/t/hanami" target="_blank">hanamimastery.com</a>, <a href="https://hanamimastery.com/t/hanami" target="_blank">Content Tagged with Hanami</a>
+
 <h2 class="page-header">Mailing List</h2>
 <p>To stay updated with the latest releases, to receive code examples, implementation details and announcements, please consider to subscribe to the <a href="/mailing-list">Hanami mailing list</a>.</p>
 


### PR DESCRIPTION
### Overview

[Hanami Mastery](https://hanamimastery.com) is a valuable source of learning resources related to Hanami.

Therefore, it makes sense to link to the Hanami topic within the community website