### PR TITLE
Change note on homepage to mention monthly alpha releases

### DIFF
--- a/source/_hanami2.erb
+++ b/source/_hanami2.erb
@@ -1,7 +1,7 @@
 <div id="hanami2" class="text-xs-center">
   <div class="container">
     <div class="row">
-      We're working on <strong>Hanami 2.0</strong>. Read the <a href="/blog/2021/05/04/announcing-hanami-200alpha2/">latest announcement</a> and follow the <a href="https://github.com/hanami/hanami/tree/main">progress</a> on GitHub.
+      We're working on <strong>Hanami 2.0</strong>, and making monthly alpha releases. Read the <a href="/blog/2021/11/09/announcing-hanami-200alpha3/">latest announcement</a> and follow the <a href="https://github.com/hanami/hanami/tree/main">progress</a> on GitHub.
     </div>
   </div>
 </div>


### PR DESCRIPTION
I went to update the blog post link and figured we might as well mention the new committment to monthly alpha releases too