### PR TITLE
Fix top banner on tiny screens & update link

### DIFF
--- a/source/_hanami2.erb
+++ b/source/_hanami2.erb
@@ -1,7 +1,9 @@
 <div id="hanami2" class="text-xs-center">
   <div class="container">
     <div class="row">
-      We're working on <strong>Hanami 2.0</strong>, and making monthly alpha releases. Read the <a href="/blog/2021/11/09/announcing-hanami-200alpha3/">latest announcement</a> and follow the <a href="https://github.com/hanami/hanami/tree/main">progress</a> on GitHub.
+      We're working on <strong>Hanami 2.0</strong>, and making monthly alpha releases.
+
+      Read the <a href="/blog/">latest announcement</a> and follow the <a href="https://github.com/hanami/hanami/tree/main">progress</a> on GitHub.
     </div>
   </div>
 </div>

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -219,19 +219,27 @@ div.supporters {
   font-weight: 300;
 }
 
-#lotus, #hanami2 {
+#hanami2 {
   color: #fff;
   background-color: #685D9F;
-  line-height: 5em;
-  margin-top: 2em;
+  line-height: 2;
+  min-height: 4em;
+  padding: 1em;
 }
 
-#lotus a, #hanami2 a {
+
+@media (max-width: 768px) {
+  #hanami2 {
+    margin-top: 0;
+  }
+}
+
+#hanami2 a {
   color: #fff;
   text-decoration: underline;
 }
 
-#lotus a.anchor, #hanami2 a.anchor {
+#hanami2 a.anchor {
   text-decoration: none;
   position: relative;
   left: -20px;
@@ -239,7 +247,7 @@ div.supporters {
   opacity: 0;
 }
 
-#lotus:hover a.anchor, #hanami2:hover a.anchor {
+#hanami2:hover a.anchor {
   opacity: 1;
 }
 


### PR DESCRIPTION
This updates the banner link to just go to `/blog/` so that we don't have to update it every month. It was outdated anyway, so this is a more 'permanent' fix.


Before:
<img width="393" alt="image" src="https://user-images.githubusercontent.com/632942/150397280-76fa2b6c-4c91-44d0-9192-8b6b2f7f2161.png">

After:
<img width="384" alt="image" src="https://user-images.githubusercontent.com/632942/150397350-d5511a67-0b07-467c-b294-070b3a9e1aa8.png">


It also decreases the height slightly on desktop, but it's still plenty big.