### PR TITLE
Fixes incorrect require in alpha8 release notes

### DIFF
--- a/source/blog/2022-05-19-announcing-hanami-200alpha8.html.markdown
+++ b/source/blog/2022-05-19-announcing-hanami-200alpha8.html.markdown
@@ -19,7 +19,7 @@ This release includes new base classes for actions and views that integrate with
 ```ruby
 # lib/my_app/action/base.rb:
 
-require "hanami/application/view"
+require "hanami/application/action"
 
 module MyApp
   module Action


### PR DESCRIPTION
I guess the Action base class should require the `hanami/application/action` and not `/view`, but I might be totally wrong though 😄 