### PR TITLE
Update to Contributor Covenant 2.1

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -101,7 +101,6 @@ title: Community
   professional setting</li>
 </ul>
 
-
 <h3 id="enforcement-responsibilities">Enforcement Responsibilities</h2>
 <p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.</p>
 <p>Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.</p>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -71,80 +71,66 @@ title: Community
 <p>Help is welcome and much appreciated, whether you are an experienced developer or just looking for sending your first pull request. Please check the open tikets. Be sure to follow the Contributor Code of Conduct below.</p>
 <a href="https://github.com/search?utf8=%E2%9C%93&q=user%3Ahanami+state%3Aopen+label%3Aeasy+label%3Ahelp-wanted&type=Issues&ref=searchresults" target="_blank">Open Tickets</a>
 
+<%# BEGIN CODE OF CONDUCT %>
+<h2 class="page-header" id="code-of-conduct">Contributor Covenant Code of Conduct</h2>
 
-<a name="code-of-conduct"></a>
+<h3 id="our-pledge">Our Pledge</h2>
+<p>We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.</p>
+<p>We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.</p>
 
-<h2 class="page-header">Contributor Code of Conduct</h2>
-<h3>Our Pledge</h3>
-
-<p>In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.</p>
-
-<h3>Our Standards</h3>
-
-<p>Examples of behavior that contribute to creating a positive environment
-include:</p>
-
+<h3 id="our-standards">Our Standards</h2>
+<p>Examples of behavior that contributes to a positive environment for our community include:</p>
 <ul>
-  <li>Using welcoming and inclusive language</li>
-  <li>Being respectful of differing viewpoints and experiences</li>
-  <li>Gracefully accepting constructive criticism</li>
-  <li>Focusing on what is best for the community</li>
-  <li>Showing empathy towards other community members</li>
+  <li>Demonstrating empathy and kindness toward other people</li>
+  <li>Being respectful of differing opinions, viewpoints, and experiences</li>
+  <li>Giving and gracefully accepting constructive feedback</li>
+  <li>Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience</li>
+  <li>Focusing on what is best not just for us as individuals, but for the overall
+  community</li>
 </ul>
-
-<p>Examples of unacceptable behavior by participants include:</p>
-
+<p>Examples of unacceptable behavior include:</p>
 <ul>
-  <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
-  <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+  <li>The use of sexualized language or imagery, and sexual attention or advances of
+  any kind</li>
+  <li>Trolling, insulting or derogatory comments, and personal or political attacks</li>
   <li>Public or private harassment</li>
-  <li>Publishing others' private information, such as a physical or electronic address, without explicit permission</li>
-  <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+  <li>Publishing others’ private information, such as a physical or email address,
+  without their explicit permission</li>
+  <li>Other conduct which could reasonably be considered inappropriate in a
+  professional setting</li>
 </ul>
 
-<h3>Our Responsibilities</h3>
 
-<p>Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.</p>
+<h3 id="enforcement-responsibilities">Enforcement Responsibilities</h2>
+<p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.</p>
+<p>Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.</p>
 
-<p>Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.</p>
+<h3 id="scope">Scope</h2>
+<p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
 
-<h3>Scope</h3>
+<h3 id="enforcement">Enforcement</h2>
+<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at admin@hanamirb.org. All complaints will be reviewed and investigated promptly and fairly.</p>
+<p>All community leaders are obligated to respect the privacy and security of the reporter of any incident.</p>
 
-<p>This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.</p>
+<h3 id="enforcement-guidelines">Enforcement Guidelines</h2>
+<p>Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:</p>
+<h4 id="1-correction">1. Correction</h3>
+<p><strong>Community Impact</strong>: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.</p>
+<p><strong>Consequence</strong>: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.</p>
+<h4 id="2-warning">2. Warning</h3>
+<p><strong>Community Impact</strong>: A violation through a single incident or series of actions.</p>
+<p><strong>Consequence</strong>: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.</p>
+<h4 id="3-temporary-ban">3. Temporary Ban</h3>
+<p><strong>Community Impact</strong>: A serious violation of community standards, including sustained inappropriate behavior.</p>
+<p><strong>Consequence</strong>: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.</p>
+<h4 id="4-permanent-ban">4. Permanent Ban</h3>
+<p><strong>Community Impact</strong>: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.</p>
+<p><strong>Consequence</strong>: A permanent ban from any sort of public interaction within the community.</p>
 
-<h3>Enforcement</h3>
-
-<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at admin@hanamirb.org. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.</p>
-
-<p>Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.</p>
-
-<h3>Attribution</h3>
-
-<p>This Code of Conduct is adapted from the <a href="http://contributor-covenant.org">Contributor Covenant</a>, version 1.4,
-available at <a href="http://contributor-covenant.org/version/1/4/">http://contributor-covenant.org/version/1/4</a>.</p>
+<h3 id="attribution">Attribution</h2>
+<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, version 2.1, available at <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">https://www.contributor-covenant.org/version/2/1/code_of_conduct.html</a>.</p>
+<%# END CODE OF CONDUCT %>
 
 <h2 class="page-header">Logos</h2>
 <p>The Hanami logo is © Luca Guidi, but you can download and use it for non-commercial purposes.</p>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -129,7 +129,7 @@ title: Community
 <p><strong>Consequence</strong>: A permanent ban from any sort of public interaction within the community.</p>
 
 <h3 id="attribution">Attribution</h2>
-<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, version 2.1, available at <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">https://www.contributor-covenant.org/version/2/1/code_of_conduct.html</a>.</p>
+<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">version 2.1</a>.</p>
 <%# END CODE OF CONDUCT %>
 
 <h2 class="page-header">Logos</h2>


### PR DESCRIPTION
Update to Version 2.1 of the Contributor Covenant as Hanami's code of conduct. This version much more clearly specifies the enforcement guidelines for the code.

We continue to retain admin@hanamirb.org as the point of contact here.

I've double checked that this renders nicely on the site, and you can check for yourself at https://deploy-preview-563--hanamirb.netlify.app/community.

@jodosha @solnic — I'd appreciate it if you could both review and approve this PR to make it clear that this Code of Conduct update is approved by everyone in the Hanami core team. Thank you! 🙇🏼 