### PR TITLE
Improve sizing and spacing of logos in trusted by section of homepage

### DIFF
--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -81,66 +81,65 @@
         </div>
         <hr>
         <div class="row">
-          <div class="col-sm-8 col-sm-offset-2 text-center m-b-lg">
-            <p class="lead m-x-auto">Trusted by</p>
+          <div class="col-sm-8 col-sm-offset-2 text-center m-b-lg p-t-sm">
+            <p class="lead m-x-auto m-b-0">Trusted by</p>
           </div>
         </div>
-        <div class="row text-center">
-          <div class="col-sm-4">
-            <a href="https://dnsimple.com/opensource" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/dnsimple.png" alt="DNSimple" loading="lazy">
-            </a>
+        <div id="trusted-by-logos">
+          <div class="row text-center">
+            <div class="col-sm-4">
+              <a href="https://dnsimple.com/opensource" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/dnsimple.png" alt="DNSimple" loading="lazy">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://www.freework.com" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/freework.png" alt="Freework" loading="lazy">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://www.advanon.com" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/advanon.png" alt="advanon" loading="lazy">
+              </a>
+            </div>
           </div>
-          <div class="col-sm-4">
-            <a href="https://www.freework.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/freework.png" alt="Freework" loading="lazy">
-            </a>
+          <div class="row text-center">
+            <div class="col-sm-4">
+              <a href="http://hellohippo.com" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/hippo.png" alt="hippo" loading="lazy" style="max-height: 65%;">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://ppe-analytics.com/index_en.html" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/ppe-analytics.png" alt="ppe-analytics" loading="lazy">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://flooringstores.com" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/flooring-stores.png" alt="flooring-stores" loading="lazy">
+              </a>
+            </div>
           </div>
-          <div class="col-sm-4">
-            <a href="https://www.advanon.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/advanon.png" alt="advanon" loading="lazy">
-            </a>
+          <div class="row text-center">
+            <div class="col-sm-4">
+              <a href="https://marozed.ma" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/marozed.png" alt="Marozed Web Agency" loading="lazy">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://ascendaloyalty.com" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/ascenda-loyalty.png" alt="Ascenda Loyalty" loading="lazy">
+              </a>
+            </div>
+            <div class="col-sm-4">
+              <a href="https://playguide.eu" rel="noopener noreferrer" target="_blank">
+                <img src="/images/companies/playguide.png" alt="PlayGuide" loading="lazy">
+              </a>
+            </div>
           </div>
         </div>
-        <br>
-        <div class="row text-center">
-          <div class="col-sm-4">
-            <a href="http://hellohippo.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/hippo.png" alt="hippo" loading="lazy">
-            </a>
-          </div>
-          <div class="col-sm-4">
-            <a href="https://ppe-analytics.com/index_en.html" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/ppe-analytics.png" alt="ppe-analytics" loading="lazy">
-            </a>
-          </div>
-          <div class="col-sm-4">
-            <a href="https://flooringstores.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/flooring-stores.png" alt="flooring-stores" loading="lazy">
-            </a>
-          </div>
-        </div>
-        <br>
-        <div class="row text-center">
-          <div class="col-sm-4">
-            <a href="https://marozed.ma" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/marozed.png" alt="Marozed Web Agency" loading="lazy">
-            </a>
-          </div>
-          <div class="col-sm-4">
-            <a href="https://ascendaloyalty.com" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/ascenda-loyalty.png" alt="Ascenda Loyalty" loading="lazy">
-            </a>
-          </div>
-          <div class="col-sm-4">
-            <a href="https://playguide.eu" rel="noopener noreferrer" target="_blank">
-              <img src="/images/companies/playguide.png" alt="PlayGuide" loading="lazy">
-            </a>
-          </div>
-        </div>
-        <br>
         <div class="row">
-          <div class="col-sm-8 col-sm-offset-2 text-center">
+          <div class="col-sm-8 col-sm-offset-2 m-t-lg p-b-sm text-center">
             <p class="m-x-auto"><a href="https://github.com/hanami/hanami.github.io/edit/build/source/layouts/home.erb" rel="noopener noreferrer" target="_blank">Are you using Hanami in production? Let us know!</a></p>
           </div>
         </div>

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -357,3 +357,28 @@ table.status td {
 .status-hanami-2-na {
   background-color: silver;
 }
+
+@media (min-width: 768px) {
+  #trusted-by-logos .row {
+    margin: 20px 0;
+  }
+}
+
+#trusted-by-logos a {
+  display: flex;
+  align-items: center;
+  height: 90px;
+}
+
+#trusted-by-logos a img {
+  max-width: 220px;
+  margin: 0 auto;
+}
+
+.p-t-sm {
+  padding-top: 10px;
+}
+
+.p-b-sm {
+  padding-bottom: 10px;
+}


### PR DESCRIPTION
The logos are a bit cramped currently, and the sizing and positioning of the Hippo and FlooringStores logos doesn't fit in. This change addresses this.

## Before - wide

![image](https://user-images.githubusercontent.com/2916331/222884065-57e4da00-e5f5-4a26-bb59-f991519abc9d.png)

## After - wide

![image](https://user-images.githubusercontent.com/2916331/222883892-85cdcc14-b9cf-4342-a671-a397cc235239.png)

## Before - narrow

![image](https://user-images.githubusercontent.com/2916331/222884474-2b2ef859-0b5b-421c-ab21-ce714cb5fd77.png)

## After - narrow

![image](https://user-images.githubusercontent.com/2916331/222884578-c0647f14-e2e1-4b86-9b0d-865aae4b7622.png)
