### PR TITLE
Add 2.x to supported versions on the security page

### DIFF
--- a/source/security.html.md
+++ b/source/security.html.md
@@ -48,4 +48,4 @@ The security announcement will contain:
 
 ## Supported versions
 
-We currently support the `1.x` series of Hanami.
+We currently support the `2.x` and `1.x` series of Hanami.


### PR DESCRIPTION
Listing Hanami 2.x as a supported version on the security page.