### PR TITLE
Remove references to Gitter, and emphasize Discourse as preferred place

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -65,8 +65,3 @@
   ga('create', 'UA-47369640-1', 'hanamirb.org');
   ga('send', 'pageview');
 </script>
-
-<script>
-  ((window.gitter = {}).chat = {}).options = { room: 'hanami/chat' };
-</script>
-<script src="//sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -9,17 +9,17 @@ title: Community
 <p>Hanami's official code repository is on Github. If you find any bugs, please report them by opening an issue. Also, pull requests are always welcome. We will get back to you as soon as possible.</p>
 <a href="https://github.com/hanami" target="_blank">github.com/hanami</a>
 
+<h2 class="page-header">Discussion Forum</h2>
+<p>The Hanami Discourse forum is the best place for any kind of discussion related to Hanami. Feel free to ask a question, share your project with others, ask for guidance and best practices, offer your help contributing to a project, or anything else.</p>
+<a href="https://discourse.hanamirb.org" target="_blank">discourse.hanamirb.org</a>
+
 <h2 class="page-header">Chat Room</h2>
-<p>We have an official chat room on Gitter. If you need a quick question answered, this is the best place to do it. Also, if you are working on a project and you need any kind of advice, please feel free to ask. Someone will be there to answer most of the times. We are always happy to help.</p>
-<a href="https://gitter.im/hanami/chat" target="_blank">hanami/chat</a>
+<p>We have an official chat room on Discourse, too. If you need a quick question answered, this is a great place for it. We are always happy to help. You need to create an account there in order to read or chat, but you can authenticate with GitHub so it's quite simple.</p>
+<a href="https://discourse.hanamirb.org/chat/c/general/6" target="_blank">Hanami Discourse Chat</a>
 
 <h2 class="page-header">Blog</h2>
 <p>On the official Hanami blog, you can find the detailed announcements for new releases, some interesting use cases and things the team writes around the code they usually write.</p>
 <a href="/blog">Hanami Blog</a>
-
-<h2 class="page-header">Discussion Forum</h2>
-<p>The Hanami forum is a good place for general discussions. Feel free to ask a question, share your project with others, ask for guidance and best practices, offer your help contributing to a project, or anything else.</p>
-<a href="https://discourse.hanamirb.org" target="_blank">discourse.hanamirb.org</a>
 
 <h2 class="page-header">Twitter</h2>
 <p>We regularly tweet general announcements on releases and events where Hanami is represented in any way. We also retweet interesting tweets from the Hanami and Ruby community. Please mention <code>@hanamirb</code> or use <code>#hanamirb</code> if you are tweeting about Hanami.</p>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -25,18 +25,6 @@ title: Community
 <p>We regularly tweet general announcements on releases and events where Hanami is represented in any way. We also retweet interesting tweets from the Hanami and Ruby community. Please mention <code>@hanamirb</code> or use <code>#hanamirb</code> if you are tweeting about Hanami.</p>
 <a href="https://twitter.com/hanamirb" target="_blank">@hanamirb</a>, <a href="https://twitter.com/search?q=hanamirb" target="_blank">#hanamirb</a>
 
-<h2 class="page-header">Reddit</h2>
-<p>On our reddit page, we link blog posts about new releases, have links to useful Hanami learning material, and have interesting discussions with the Hanami community.</p>
-<a href="https://www.reddit.com/r/hanamirb/" target="_blank">r/hanamirb</a>
-
-<h2 class="page-header">StackOverflow</h2>
-<p>If you have any questions about Hanami, you can always ask on StackOverflow. Make sure you use the Hanami tag. You can also always help others solving their problems. You will make others happy, as you are when you get help.</p>
-<a href="https://stackoverflow.com/questions/tagged/hanami" target="_blank">hanami tag</a>
-
-<h2 class="page-header">Awesome Hanami</h2>
-<p>The awesome-hanami Github repository lists Hanami gems, libraries and projects that use Hanami. Also, there are some useful links to know more about Hanami and its users.</p>
-<a href="http://awesome-hanami.org" target="_blank">awesome-hanami.org</a>
-
 <h2 class="page-header">Hanami Mastery</h2>
 <p>Hanami Mastery initiative is a collection of <strong>articles and video tutorials</strong> about Hanami and its dependencies, as well as all awesome gems that can be used within Hanami framework.</p>
 <a href="https://hanamimastery.com/t/hanami" target="_blank">hanamimastery.com</a>, <a href="https://hanamimastery.com/t/hanami" target="_blank">Content Tagged with Hanami</a>

--- a/source/stylesheets/application-minimal.css
+++ b/source/stylesheets/application-minimal.css
@@ -291,26 +291,6 @@ table.status td {
   font-size: 16px;
 }
 
-.gitter-open-chat-button {
-  background-color: #534a7f;
-  border-color: #443d68;
-}
-
-.gitter-open-chat-button:focus, .gitter-open-chat-button:hover {
-  background-color: #48416f;
-  text-decoration: none;
-}
-
-.gitter-chat-embed {
-  z-index: 1000;
-}
-
-@media (max-width: 768px) {
-  .gitter-open-chat-button {
-    display: none;
-  }
-}
-
 .hanami-release-date {
   margin-top: 1em;
   font-weight: 200;


### PR DESCRIPTION
Unfortunately the link here just goes to the Discourse forum if you're not logged in. It doesn't show any reference to the chat at all, it's even missing from the sidebar unfortunately. Is there any way to make the chat public @timriley?

Regardless, I wrote some copy that should be good enough regardless of whether it's visible or not. We can add some more text if it's not possible to make it public.

As always, open to feedback or changes to the copy.