### PR TITLE
Update community page (new conference videos, tidying)

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -97,12 +97,6 @@ title: Community
   </ul>
 </p>
 
-<h2 class="page-header">Local User Groups</h2>
-<p>Find and join a local Hanami user group and spread the word about Hanami. Share experiences and help others to get started! If you consider starting a new local user group, feel free to get in touch with us and we can help you with the setup.</p>
-<ul>
-  <li><a href="http://www.meetup.com/hanamirb-sp-brazil-meetups" target="_blank">Hanami User Group @ São Paulo, Brazil</a> (<a href="https://twitter.com/hanamirb_sp" target="_blank">@hanamirb_sp</a>)</li>
-</ul>
-
 <h2 class="page-header">Contribute to Hanami</h2>
 <p>Help is welcome and much appreciated, whether you are an experienced developer or just looking for sending your first pull request. Please check the open tikets. Be sure to follow the Contributor Code of Conduct below.</p>
 <a href="https://github.com/search?utf8=%E2%9C%93&q=user%3Ahanami+state%3Aopen+label%3Aeasy+label%3Ahelp-wanted&type=Issues&ref=searchresults" target="_blank">Open Tickets</a>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -33,10 +33,58 @@ title: Community
 <p>To stay updated with the latest releases, to receive code examples, implementation details and announcements, please consider to subscribe to the <a href="/mailing-list">Hanami mailing list</a>.</p>
 
 <h2 class="page-header">Conference Talks about Hanami</h2>
+
+<h4>Hanami 2</h4>
 <p>
   <ul>
+
+    <li>
+      <a href="https://timriley.info/">Tim Riley</a> -
+      <a href="https://www.youtube.com/watch?v=vKWAjGatDa0">Livin' La Vida Hanami</a>
+      - @
+      <a href="https://rubyconf.org/">RubyConf 2023</a>
+    </li>
+
+    <li>
+      <a href="https://alchemists.io">Brooke Kuhlman</a> -
+      <a href="https://www.youtube.com/watch?v=vVMZ6qhdxkg">Return To Simplicity: Architect Hypermedia REST applications using Hanami + HTMX</a>
+      - @
+      <a href="https://rockymtnruby.dev/">Rocky Mountain Ruby 2023</a>
+    </li>
+
+    <li>
+      <a href="https://timriley.info/">Tim Riley</a> -
+      <a href="https://www.youtube.com/watch?v=jxJ4-iadvIk">Hanami 2: New Framework, New You</a>
+      - @
+      <a href="https://rubyconf.org/">RubyConfTH 2022</a>
+    </li>
+
+    <li>
+      <a href="https://twitter.com/jodosha">Luca Guidi</a> -
+      <a href="https://www.youtube.com/watch?v=7DABLhbNy0I">Keynote (Hanami 2.0)</a>
+      - @
+      <a href="https://2020.rubyparis.org/">Paris.rb Conf 2020</a>
+    </li>
+
+    <li>
+      <a href="https://twitter.com/jodosha">Luca Guidi</a> -
+      <a href="https://www.youtube.com/watch?v=LqGBhTSOmTI">Hanami 2.0</a>
+      - @
+      <a href="https://2019.rubyday.it/">rubyday 2019</a>
+    </li>
+
+  </ul>
+</p>
+
+
+<h4>Hanami 1</h4>
+<p>
+  <ul>
+    <li><a href="http://stdout.in/">Yevhen Kuzminov</a> - <a href="https://www.youtube.com/watch?v=jDMUBRPI5zc">A year with Hanami in production: the Good, the Bad and some Recipes</a> - @ <a href="https://rubyc.eu/archives/9/">RubyC 2019</a></li>
+    <li>Grzegorz Witek - <a href="https://www.youtube.com/watch?v=w9VXhtSlhGI">One year with Hanami - what we love, what we don't </a> - @ DeccanRubyConf 2018</a></li>
     <li><a href="https://twitter.com/parndt">Philip Arndt</a> and <a href="https://twitter.com/samseay">Samuel Seay</a> - <a href="https://www.youtube.com/watch?v=aVxJ0GyD3vw">Taking Refinery off the Rails</a> - @ <a href="http://www.rubyconf.org.au/2017">RubyConf AU 2017</a></li>
-    <li><a href="https://twitter.com/_toch">Christophe Philemotte</a> - <a href="https://speakerdeck.com/toch/build-a-web-api-with-hanami">Building a Web API with Hanami</a> - @ <a href="https://confoo.ca/en">ConFoo.CA 2017</a></li>
+    <li><a href="https://twitter.com/anton_davydov">Anton Davydov</a> - <a href="https://www.youtube.com/watch?v=aYboQzyIoPc">Hanami - New Ruby Web Framework</a> - @ <a href="https://rubykaigi.org/2017/presentations/anton_davydov.html">RubyKaigi 2017</a></li>
+    <li><a href="https://ibakesoftware.com/">Christophe Philemotte</a> - <a href="https://speakerdeck.com/toch/build-a-web-api-with-hanami">Building a Web API with Hanami</a> - @ <a href="https://confoo.ca/en">ConFoo.CA 2017</a></li>
     <li><a href="https://twitter.com/jodosha">Luca Guidi</a> - <a href="https://www.youtube.com/watch?v=0RyitUKfUFE">Lessons Learned While Building Hanami</a> - @ <a href="http://www.rubyday.it/">RubyDay IT 2016</li>
     <li><a href="https://twitter.com/_toch">Christophe Philemotte</a> - <a href="https://speakerdeck.com/toch/build-a-web-api-with-hanami">Building a Web API with Hanami</a> - @ <a href="http://takeoffconf.com/2016">TakeOffConf 2016</a></li>
     <li><a href="https://twitter.com/jmcharnes">Jason Charnes</a> - <a href="https://www.youtube.com/watch?v=99mCHPZ-Qro">A Handy Look at Hanami</a> - @ <a href="http://www.codedaze.io/">Daze Conf 2016</a></li>

--- a/source/ml/0009/index.html
+++ b/source/ml/0009/index.html
@@ -1506,7 +1506,7 @@ Developing and maintaining a platform with Rails and Hanami
                                                             </td>
                                                             <td mc:edit="content-title-140" data-link-style="text-decoration:none; color:#dc3610;" data-link-color="Content Link x2" data-color="Headline x2" data-size="Headline x2" align="left" style="font-family: 'Open Sans', Arial, sans-serif; color: rgb(52, 152, 219); font-size: 14px; font-weight: normal; line-height: 23.8px;">
                                                                 <singleline>
-                                                                    <a href="http://solnic.eu/2016/05/22/my-time-with-rails-is-up.html?utm_campaign=ml0009&utm_source=hanami&utm_medium=link">Learn More</a>
+                                                                    <a href="https://solnic.dev/my-time-with-rails-is-up">Learn More</a>
                                                                 </singleline>
                                                             </td>
                                                         </tr>


### PR DESCRIPTION
1. Add a section to "conference talks" for Hanami 2 (and move all the old ones to a Hanami 1 section)
2. Add all the Hanami 2 talks I could find
3. Add some Hanami 1 talks, update an outdated twitter link to their homepage
4. Remove the "Local User Groups" section since the one there doesn't seem active
5. Update a link to a blog post in a different file

I checked my work manually but I wasn't able to get the dev server working locally, due to old versions of middleman. I'm looking forward to updating the site with a new design and tech stack :D 