### PR TITLE
Add `rel="me"` attribute to Mastodon account link

### DIFF
--- a/source/_footer.erb
+++ b/source/_footer.erb
@@ -20,7 +20,7 @@
           <li><a href="/community#code-of-conduct">Code of Conduct</a></li>
           <li><a href="https://discourse.hanamirb.org" target="_blank">Forum</a></li>
           <li><a href="https://discord.gg/KFCxDmk3JQ" target="_blank">Chat</a></li>
-          <li><a href="https://ruby.social/@hanami" target="_blank">Mastodon</a></li>
+          <li><a href="https://ruby.social/@hanami" rel="me" target="_blank">Mastodon</a></li>
           <li><a href="https://bsky.app/profile/hanamirb.org" target="_blank">Bluesky</a></li>
           <li><a href="https://stackoverflow.com/questions/tagged/hanami" target="_blank">StackOverflow</a></li>
         </ul>


### PR DESCRIPTION
Thanks for considering this change!

Mastodon supports profile verification out-of-the-box:

https://joinmastodon.org/verification

This change adds the necessary `rel="me"` attribute to the link to Hanami's Mastodon profile in the website footer. Someone with admin access to the Mastodon account could then add a link to `https://hanamirb.org` by navigating to:

https://ruby.social/settings/profile

…and adding the link to the "Extra Fields" configuration.

Boom, verified links!

(also, it'd be super helpful to have a link to Hanami's homepage when viewing y'all's Mastodon profile)