### PR TITLE
Adopt Contributor Covenant 3.0

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -83,61 +83,91 @@ title: Community
 <%# BEGIN CODE OF CONDUCT %>
 <h2 class="page-header" id="code-of-conduct">Contributor Covenant Code of Conduct</h2>
 
-<h3 id="our-pledge">Our Pledge</h2>
-<p>We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.</p>
-<p>We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.</p>
+<h3 id="our-pledge">Our Pledge</h3>
+<p>We pledge to make our community welcoming, safe, and equitable for all.</p>
+<p>We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.</p>
 
-<h3 id="our-standards">Our Standards</h2>
-<p>Examples of behavior that contributes to a positive environment for our community include:</p>
-<ul>
-  <li>Focusing on what is best not just for us as individuals, but for the overall
-  community</li>
-  <li>Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience</li>
-  <li>Giving and gracefully accepting constructive feedback</li>
-  <li>Being respectful of differing opinions, viewpoints, and experiences</li>
-  <li>Demonstrating empathy and kindness toward other people</li>
-</ul>
-<p>Examples of unacceptable behavior include:</p>
-<ul>
-  <li>Other conduct which could reasonably be considered inappropriate in a
-  professional setting</li>
-  <li>Publishing others’ private information, such as a physical or email address,
-  without their explicit permission</li>
-  <li>Public or private harassment</li>
-  <li>Trolling, insulting or derogatory comments, and personal or political attacks</li>
-  <li>The use of sexualized language or imagery, and sexual attention or advances of
-  any kind</li>
-</ul>
+<h3 id="encouraged-behaviors">Encouraged Behaviors</h3>
+<p>While acknowledging differences in social norms, we all strive to meet our community’s expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.</p>
+<p>With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:</p>
+<ol>
+  <li>Respecting the <strong>purpose of our community</strong>, our activities, and our ways of gathering.</li>
+  <li>Engaging <strong>kindly and honestly</strong> with others.</li>
+  <li>Respecting <strong>different viewpoints</strong> and experiences.</li>
+  <li><strong>Taking responsibility</strong> for our actions and contributions.</li>
+  <li>Gracefully giving and accepting <strong>constructive feedback</strong>.</li>
+  <li>Committing to <strong>repairing harm</strong> when it occurs.</li>
+  <li>Behaving in other ways that promote and sustain the <strong>well-being of our community</strong>.</li>
+</ol>
 
-<h3 id="enforcement-responsibilities">Enforcement Responsibilities</h2>
-<p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.</p>
-<p>Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.</p>
+<h3 id="restricted-behaviors">Restricted Behaviors</h3>
+<p>We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.</p>
+<ol>
+  <li><strong>Harassment.</strong> Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.</li>
+  <li><strong>Character attacks.</strong> Making insulting, demeaning, or pejorative comments directed at a community member or group of people.</li>
+  <li><strong>Stereotyping or discrimination.</strong> Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.</li>
+  <li><strong>Sexualization.</strong> Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.</li>
+  <li><strong>Violating confidentiality</strong>. Sharing or acting on someone’s personal or private information without their permission.</li>
+  <li><strong>Endangerment.</strong> Causing, encouraging, or threatening violence or other harm toward any person or group.</li>
+  <li>Behaving in other ways that <strong>threaten the well-being</strong> of our community.</li>
+</ol>
 
-<h3 id="scope">Scope</h2>
-<p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
+<h4 id="other-restrictions">Other Restrictions</h4>
+<ol>
+  <li><strong>Misleading identity.</strong> Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.</li>
+  <li><strong>Failing to credit sources.</strong> Not properly crediting the sources of content you contribute.</li>
+  <li><strong>Promotional materials</strong>. Sharing marketing or other commercial content in a way that is outside the norms of the community.</li>
+  <li><strong>Irresponsible communication.</strong> Failing to responsibly present content which includes, links or describes any other restricted behaviors.</li>
+</ol>
 
-<h3 id="enforcement">Enforcement</h2>
-<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at admin@hanamirb.org. All complaints will be reviewed and investigated promptly and fairly.</p>
-<p>All community leaders are obligated to respect the privacy and security of the reporter of any incident.</p>
+<h3 id="reporting-an-issue">Reporting an Issue</h3>
+<p>Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.</p>
+<p>When an incident does occur, it is important to report it promptly. To report a possible violation, <strong>email admin@hanamirb.org</strong>.</p>
+<p>Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.</p>
 
-<h3 id="enforcement-guidelines">Enforcement Guidelines</h2>
-<p>Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:</p>
-<h4 id="1-correction">1. Correction</h3>
-<p><strong>Community Impact</strong>: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.</p>
-<p><strong>Consequence</strong>: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.</p>
-<h4 id="2-warning">2. Warning</h3>
-<p><strong>Community Impact</strong>: A violation through a single incident or series of actions.</p>
-<p><strong>Consequence</strong>: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.</p>
-<h4 id="3-temporary-ban">3. Temporary Ban</h3>
-<p><strong>Community Impact</strong>: A serious violation of community standards, including sustained inappropriate behavior.</p>
-<p><strong>Consequence</strong>: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.</p>
-<h4 id="4-permanent-ban">4. Permanent Ban</h3>
-<p><strong>Community Impact</strong>: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.</p>
-<p><strong>Consequence</strong>: A permanent ban from any sort of public interaction within the community.</p>
+<h3 id="addressing-and-repairing-harm">Addressing and Repairing Harm</h3>
+<p>If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident’s impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.</p>
+<ol>
+  <li>
+    Warning
+    <ol>
+      <li>Event: A violation involving a single incident or series of incidents.</li>
+      <li>Consequence: A private, written warning from the Community Moderators.</li>
+      <li>Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.</li>
+    </ol>
+  </li>
+  <li>
+    Temporarily Limited Activities
+    <ol>
+      <li>Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.</li>
+      <li>Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.</li>
+      <li>Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.</li>
+    </ol>
+  </li>
+  <li>
+    Temporary Suspension
+    <ol>
+      <li>Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.</li>
+      <li>Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.</li>
+      <li>Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.</li>
+    </ol>
+  </li>
+  <li>
+    Permanent Ban
+    <ol>
+      <li>Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.</li>
+      <li>Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.</li>
+      <li>Repair: There is no possible repair in cases of this severity.</li>
+    </ol>
+  </li>
+</ol>
+<p>This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.</p>
 
-<h3 id="attribution">Attribution</h2>
-<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct.html">version 2.1</a>.</p>
+<h3 id="scope">Scope</h3>
+<p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
+
+<h3 id="attribution">Attribution</h3>
+<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/version/3/0/">Contributor Covenant, version 3.0</a>.</p>
 <%# END CODE OF CONDUCT %>
 
 <h2 class="page-header">Logos</h2>


### PR DESCRIPTION
We've always aimed to use the latest version of the [Contributor Covenant](https://www.contributor-covenant.org), the gold standard for community codes of conduct.

Version 3.0 was [released last month](https://ethicalsource.dev/blog/contributor-covenant-3/) and contains a number of improvements:

> Contributor Covenant 3.0 is designed to be more adaptable to different kinds of communities, both online and offline. It is written with clearer, less US-centric language, intended to be easier to understand and translate. The enforcement guidelines section has been reimagined as “Addressing and Repairing Harm,” reflecting an alignment with principles of restorative justice, including finding ways to safely reintegrate someone back into a community after an incident occurs.

I would like us to adopt this version for Hanami (and soon our entire ecosystem encompassing Hanami, Dry and Rom). This PR brings the new version into our community page, which is the canonical location for our code of conduct.